### PR TITLE
Enable linting on the fly

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -25,7 +25,7 @@ module.exports =
     provider =
       grammarScopes: ['text.html.php', 'source.php']
       scope: 'file'
-      lintOnFly: false
+      lintOnFly: true
       lint: (textEditor) =>
         filePath = textEditor.getPath()
         command = @executablePath
@@ -34,7 +34,7 @@ module.exports =
         parameters.push('--no-php-ini')
         parameters.push('--define', 'display_errors=On')
         parameters.push('--define', 'log_errors=Off')
-        parameters.push('--file', filePath)
-        return helpers.exec(command, parameters).then (output) =>
+        text = textEditor.getText()
+        return helpers.exec(command, parameters, {stdin: text}).then (output) =>
           messages = helpers.parse(output, @regex, {filePath: filePath})
           return messages


### PR DESCRIPTION
Note that this represents a slight loss of functionality. With the update to the new API the file was explicitly specified, which according to the documentation enables checking for "fatal errors (like undefined functions)".

Since we are linting on the fly we can't specify a file and thus lose this functionality.

I would say that the added benefit of having on the fly linting capabilities is worth the return to the original functionality.