### PR TITLE
Fix indentation in coffeelint.json

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,6 +1,6 @@
 {
   "max_line_length": {
-		"value": 120,
+    "value": 120,
     "level": "warn"
   },
   "no_empty_param_list": {


### PR DESCRIPTION
Atom apparently decided that this was a tab-based file even though all other lines were spaces...