### PR TITLE
Add Maintainers section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ Please note that modifications should follow these coding guidelines:
 The following people have stepped up to take responsibility for this repository and should be consulted on any releases or major changes.
 
 * [steelbrain](http://github.com/steelbrain) - Release Maintainer
+* [Arcanemagus](http://github.com/Arcanemagus)

--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ Please note that modifications should follow these coding guidelines:
 - Vertical whitespace helps readability, don’t be afraid to use it.
 
 **Thank you for helping out!**
+
+## Maintainers
+
+The following people have stepped up to take responsibility for this repository and should be consulted on any releases or major changes.
+
+* [steelbrain](http://github.com/steelbrain) - Release Maintainer


### PR DESCRIPTION
I'd like to come up with a standard format we can copy into all of the repositories.

@Arcanemagus I wasn't sure if you should be included here or not. You do have commit access, but I think it's between you and @steelbrain to decide how things get released.

While working on the core linter there were a couple of situations where we needed to patch one of `linter-*` and I didn't know who had taken responsibility for releases. If we have multiple people listed under Maintainers I think one should be generally in charge of releases.