### PR TITLE
Automatically install linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # linter-php
 =========================
 
-This package will lint your `.php` opened filed in Atom through [php -l](http://www.php.net/manual/en/features.commandline.options.php).
+This package will lint PHP files and embedded PHP within HTML files in Atom through
+[php -l](http://www.php.net/manual/en/features.commandline.options.php).
 
 ## Installation
-Linter package must be installed in order to use this plugin. If Linter is not installed, please follow the instructions [here](https://github.com/AtomLinter/Linter).
+As this package only provides a service, you will need something to run it. As
+such, the Linter package will be installed for you if it isn't already installed.
+This provides the interface and runs the linter for you.
 
 * Install [php](http://php.net).
 * `$ apm install linter-php`

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -8,6 +8,7 @@ module.exports =
       default: 'php' # Let OS's $PATH handle the rest
 
   activate: ->
+    require('atom-package-deps').install('linter-php')
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.config.observe 'linter-php.executablePath',
       (executablePath) =>

--- a/package.json
+++ b/package.json
@@ -6,8 +6,12 @@
   "repository": "https://github.com/AtomLinter/linter-php",
   "license": "MIT",
   "dependencies": {
-    "atom-linter": "^3.0.0"
+    "atom-linter": "^3.0.0",
+    "atom-package-deps": "^2.1.3"
   },
+  "package-deps": [
+    "linter"
+  ],
   "providedServices": {
     "linter": {
       "versions": {


### PR DESCRIPTION
Automatically installs the `linter` package, if it wasn't installed already.

Closes #63.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-php/64)
<!-- Reviewable:end -->
