### PR TITLE
Update atom-linter required version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/AtomLinter/linter-php",
   "license": "MIT",
   "dependencies": {
-    "atom-linter": "^3.0.0",
+    "atom-linter": "^3.1.0",
     "atom-package-deps": "^2.1.3"
   },
   "package-deps": [


### PR DESCRIPTION
helpers.rangeFromLineNumber was implemented in v3.1.0, update `package.json` to reflect that that is the minimum required version.