### PR TITLE
Only activate when needed

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -42,7 +42,7 @@ module.exports =
       lint: (textEditor) =>
         filePath = textEditor.getPath()
         command = @executablePath
-        return [] unless command?
+        return Promise.resolve([]) unless command?
         parameters = []
         parameters.push('--syntax-check')
         parameters.push('--no-php-ini')
@@ -58,4 +58,4 @@ module.exports =
               filePath: filePath
               range: helpers.rangeFromLineNumber(textEditor, match[2] - 1)
               text: match[1]
-          return messages
+          messages

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Lint PHP on the fly, using php -l",
   "repository": "https://github.com/AtomLinter/linter-php",
   "license": "MIT",
+  "activationHooks": ["language-php:grammar-used"],
   "dependencies": {
     "atom-linter": "^3.1.0",
     "atom-package-deps": "^2.1.3"

--- a/spec/linter-php-spec.js
+++ b/spec/linter-php-spec.js
@@ -4,16 +4,54 @@ describe('The php -l provider for Linter', () => {
   const lint = require('../lib/main').provideLinter().lint;
 
   beforeEach(() => {
+    atom.workspace.destroyActivePaneItem()
     waitsForPromise(() => {
-      return atom.packages.activatePackage("linter-php");
+      atom.packages.activatePackage('linter-php')
     });
+    // return atom.packages.activatePackage("language-php").then(() =>
+    //     atom.packages.activatePackage("language-php")
+    //   );
+      // Promise.all([
+      //   atom.packages.activatePackage("language-php"),
+      //   atom.packages.activatePackage("language-php")
+      // ]);
+    // });
+    // waitsForPromise(() => {
+    //   return atom.packages.triggerActivationHook('language-php:grammar-used');
+    // // });
+    // atom.packages.triggerActivationHook('language-php:grammar-used');
   });
 
-  it('finds a syntax error in bad.php', () => {
-    waitsForPromise(() => {
-      return atom.workspace.open(__dirname + '/files/bad.php').then(editor => {
+  it('should be in the packages list', () => {
+    return expect(atom.packages.isPackageLoaded('linter-php')).toBe(true);
+  });
+
+  it('should be an active package', () => {
+    return expect(atom.packages.isPackageActive('linter-php')).toBe(true);
+  });
+
+  describe('checks bad.php and', () => {
+    let editor = null;
+    beforeEach(() => {
+      waitsForPromise(() => {
+        return atom.workspace.open(__dirname + '/files/bad.php').then(openEditor => {
+          editor = openEditor;
+        });
+      });
+      atom.packages.triggerActivationHook('language-php:grammar-used');
+    });
+
+    it('finds at least one message', () => {
+      waitsForPromise(() => {
         return lint(editor).then(messages => {
           expect(messages.length).toEqual(1);
+        });
+      });
+    });
+
+    it('verifies that message', () => {
+      waitsForPromise(() => {
+        return lint(editor).then(messages => {
           expect(messages[0].type).toBeDefined();
           expect(messages[0].type).toEqual('Error');
           expect(messages[0].text).toBeDefined();

--- a/spec/linter-php-spec.js
+++ b/spec/linter-php-spec.js
@@ -4,22 +4,13 @@ describe('The php -l provider for Linter', () => {
   const lint = require('../lib/main').provideLinter().lint;
 
   beforeEach(() => {
-    atom.workspace.destroyActivePaneItem()
+    atom.workspace.destroyActivePaneItem();
     waitsForPromise(() => {
-      atom.packages.activatePackage('linter-php')
+      atom.packages.activatePackage('linter-php');
+      return atom.packages.activatePackage('language-php').then(() =>
+        atom.workspace.open(__dirname + '/files/bad.php')
+      );
     });
-    // return atom.packages.activatePackage("language-php").then(() =>
-    //     atom.packages.activatePackage("language-php")
-    //   );
-      // Promise.all([
-      //   atom.packages.activatePackage("language-php"),
-      //   atom.packages.activatePackage("language-php")
-      // ]);
-    // });
-    // waitsForPromise(() => {
-    //   return atom.packages.triggerActivationHook('language-php:grammar-used');
-    // // });
-    // atom.packages.triggerActivationHook('language-php:grammar-used');
   });
 
   it('should be in the packages list', () => {
@@ -38,7 +29,6 @@ describe('The php -l provider for Linter', () => {
           editor = openEditor;
         });
       });
-      atom.packages.triggerActivationHook('language-php:grammar-used');
     });
 
     it('finds at least one message', () => {


### PR DESCRIPTION
Utilize the activationHooks in `package.json` to only load this package when a file with the PHP grammar has been opened.

Fixes #86.