### PR TITLE
Fix the specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "language-php:grammar-used"
   ],
   "dependencies": {
-    "atom-linter": "^3.3.1",
-    "atom-package-deps": "^3.0.0"
+    "atom-linter": "^3.3.3",
+    "atom-package-deps": "^3.0.2"
   },
   "devDependencies": {
     "coffeelint": "^1.13.1"

--- a/spec/linter-php-spec.js
+++ b/spec/linter-php-spec.js
@@ -50,7 +50,7 @@ describe('The php -l provider for Linter', () => {
           expect(messages[0].filePath).toMatch(/.+bad\.php$/);
           expect(messages[0].range).toBeDefined();
           expect(messages[0].range.length).toEqual(2);
-          expect(messages[0].range).toEqual([[1, 0], [1, 6]]);
+          expect(messages[0].range).toEqual([[1, 0], [1, 5]]);
         });
       });
     });


### PR DESCRIPTION
Due to a bug in `atom-linter` it was returning an end column 1 past the end of the line, this fixes the specs for the latest version.