### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.l.3
+* Stop ignoring `php.ini`
+
 # v1.1.2
 * Update package dependencies to clear an Atom deprecation issue
 

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "language-php:grammar-used"
   ],
   "dependencies": {
-    "atom-linter": "^3.3.3",
+    "atom-linter": "^3.3.6",
     "atom-package-deps": "^3.0.2"
   },
   "devDependencies": {
-    "coffeelint": "^1.13.1",
+    "coffeelint": "^1.14.0",
     "eslint": "^1.9.0",
     "babel-eslint": "^4.1.5",
     "eslint-config-airbnb": "latest"


### PR DESCRIPTION
Update `atom-linter` to grab more checks against invalid input.
Add a changelog entry.