### PR TITLE
Correct the range

### DIFF
--- a/spec/linter-php-spec.js
+++ b/spec/linter-php-spec.js
@@ -51,7 +51,7 @@ describe('The php -l provider for Linter', () => {
           expect(messages[0].filePath).toMatch(/.+bad\.php$/);
           expect(messages[0].range).toBeDefined();
           expect(messages[0].range.length).toEqual(2);
-          expect(messages[0].range).toEqual([[1, 0], [1, 5]]);
+          expect(messages[0].range).toEqual([[1, 0], [1, 6]]);
         });
       });
     });


### PR DESCRIPTION
`atom-linter` was generating incorrect ranges due to a misconception, this fixes the specs to match the correct values.