### PR TITLE
Update Travis-CI for multiple PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,55 @@
-sudo: true
+
+sudo: false
+
 git:
   depth: 10
+
 branches:
   only:
     - master
+
 notifications:
   email:
     on_success: never
     on_failure: change
-os: osx
-before_install:
-  # Updating PHP to 5.6
-  - curl -s http://php-osx.liip.ch/install.sh | bash -s 5.6
-  - export PATH=/usr/local/php5/bin:$PATH
-  - php --version
 
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+language: php
+matrix:
+  include:
+    - os: linux
+      php: '5.5'
+    - os: linux
+      php: '5.6'
+    - os: linux
+      php: '7.0'
+    - os: linux
+      php: '7.0'
+      env:
+        - ATOM_CHANNEL=beta
+    - os: osx
+      language: generic
+      before_install:
+        # Updating PHP to 5.6.x
+        - curl -s http://php-osx.liip.ch/install.sh | bash -s 5.6
+        - export PATH=/usr/local/php5/bin:$PATH
+    - os: osx
+      osx_image: xcode7.2
+      language: generic
+      env:
+        - ATOM_CHANNEL=beta
+      before_install:
+        # Updating PHP to 7.0.x
+        - curl -s http://php-osx.liip.ch/install.sh | bash -s 7.0
+        - export PATH=/usr/local/php5/bin:$PATH
+
+script:
+  - php --version
+  - 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+
+addons:
+  apt:
+    packages:
+    - build-essential
+    - git
+    - libgnome-keyring-dev
+    - fakeroot


### PR DESCRIPTION
Utilize Travic-CI's matrix feature to test all three currently supported PHP versions.

Specifically, Travis-CI now runs the following:
* PHP 5.5.x, 5.6.x, and 7.0.x (Stable + Beta) on Linux
* PHP 5.6.x on Stable and PHP 7.0.x on Beta on OS X