### PR TITLE
Short tag didn't work for me by default

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -45,6 +45,7 @@ module.exports =
         return Promise.resolve([]) unless command?
         parameters = []
         parameters.push('--syntax-check')
+        parameters.push('--define', 'short_open_tag=On')
         parameters.push('--define', 'display_errors=On')
         parameters.push('--define', 'log_errors=Off')
         text = textEditor.getText()


### PR DESCRIPTION
My php.ini short_open_tag parameter is set to "On", but linter didn't lint by default even i ran linter from console. Big part of my files at work use short tag notation. So add please this.