### PR TITLE
Handle Fatal errors

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -49,7 +49,7 @@ module.exports =
         parameters.push('--define', 'log_errors=Off')
         text = textEditor.getText()
         return helpers.exec(command, parameters, {stdin: text}).then (output) ->
-          regex = /^Parse error:\s+(.+) in .+? on line (\d+)/gm
+          regex = /^(?:Parse|Fatal) error:\s+(.+) in .+? on line (\d+)/gm
           messages = []
           while((match = regex.exec(output)) isnt null)
             messages.push

--- a/spec/files/fatal.php
+++ b/spec/files/fatal.php
@@ -1,0 +1,15 @@
+<?php
+namespace Test;
+
+class A
+{
+    public function foo()
+    {
+
+    }
+
+    public function foo()
+    {
+
+    }
+}

--- a/spec/linter-php-spec.js
+++ b/spec/linter-php-spec.js
@@ -6,6 +6,7 @@ import * as path from 'path';
 const badPath = path.join(__dirname, 'files', 'bad.php');
 const goodPath = path.join(__dirname, 'files', 'good.php');
 const emptyPath = path.join(__dirname, 'files', 'empty.php');
+const fatalPath = path.join(__dirname, 'files', 'fatal.php');
 
 describe('The php -l provider for Linter', () => {
   const lint = require('../lib/main').provideLinter().lint;
@@ -54,7 +55,7 @@ describe('The php -l provider for Linter', () => {
           expect(messages[0].text).toBeDefined();
           expect(messages[0].text).toEqual('syntax error, unexpected \'{\'');
           expect(messages[0].filePath).toBeDefined();
-          expect(messages[0].filePath).toMatch(/.+bad\.php$/);
+          expect(messages[0].filePath).toEqual(badPath);
           expect(messages[0].range).toBeDefined();
           expect(messages[0].range.length).toEqual(2);
           expect(messages[0].range).toEqual([[1, 0], [1, 6]]);
@@ -78,6 +79,19 @@ describe('The php -l provider for Linter', () => {
       atom.workspace.open(goodPath).then(editor =>
         lint(editor).then(messages => {
           expect(messages.length).toEqual(0);
+        })
+      )
+    );
+  });
+
+  it('handles fatal errors', () => {
+    waitsForPromise(() =>
+      atom.workspace.open(fatalPath).then(editor =>
+        lint(editor).then(messages => {
+          expect(messages[0].type).toEqual('Error');
+          expect(messages[0].text).toEqual('Cannot redeclare Test\\A::foo()');
+          expect(messages[0].filePath).toBe(fatalPath);
+          expect(messages[0].range).toEqual([[10, 4], [10, 25]]);
         })
       )
     );


### PR DESCRIPTION
Apparently there are at least two types of PHP errors that can be thrown, handle `Fatal` as well as `Parse` errors.

For testing of the Regex see [here](https://regex101.com/r/oH9zI4/1)

Fixes #140.