### PR TITLE
Move to eslint-config-airbnb-base

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,21 +6,21 @@
   "repository": "https://github.com/AtomLinter/linter-php",
   "license": "MIT",
   "dependencies": {
-    "atom-linter": "^4.6.1",
+    "atom-linter": "^4.7.0",
     "atom-package-deps": "^4.0.1"
   },
   "devDependencies": {
-    "coffeelint": "^1.15.0",
-    "eslint": "^2.7.0",
-    "eslint-config-airbnb": "^7.0.0",
-    "eslint-plugin-react": "^4.3.0",
-    "eslint-plugin-jsx-a11y": "^0.6.2"
+    "coffeelint": "^1.15.2",
+    "eslint": "^2.8.0",
+    "eslint-config-airbnb-base": "^1.0.3",
+    "eslint-plugin-import": "^1.5.0"
   },
   "package-deps": [
     "linter"
   ],
   "scripts": {
-    "lint": "./node_modules/.bin/coffeelint lib"
+    "test": "apm test",
+    "lint": "coffeelint lib && eslint spec"
   },
   "providedServices": {
     "linter": {
@@ -30,7 +30,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "airbnb/base",
+    "extends": "airbnb-base",
     "globals": {
       "atom": true
     },

--- a/spec/.eslintrc.js
+++ b/spec/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
-  globals: {
-    waitsForPromise: true
+  env: {
+    jasmine: true,
+    atomtest: true
   }
 };

--- a/spec/linter-php-spec.js
+++ b/spec/linter-php-spec.js
@@ -8,9 +8,9 @@ const goodPath = path.join(__dirname, 'files', 'good.php');
 const emptyPath = path.join(__dirname, 'files', 'empty.php');
 const fatalPath = path.join(__dirname, 'files', 'fatal.php');
 
-describe('The php -l provider for Linter', () => {
-  const lint = require('../lib/main').provideLinter().lint;
+const lint = require('../lib/main.coffee').provideLinter().lint;
 
+describe('The php -l provider for Linter', () => {
   beforeEach(() => {
     atom.workspace.destroyActivePaneItem();
     waitsForPromise(() => {


### PR DESCRIPTION
We have no use for the React components of eslint-config-airbnb.

Closes #156.
Closes #160.