### PR TITLE
Pass project path of file to the command as cwd

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,5 +1,6 @@
 {CompositeDisposable} = require 'atom'
 helpers = require('atom-linter')
+path = require('path')
 
 module.exports =
   config:
@@ -48,7 +49,9 @@ module.exports =
         parameters.push('--define', 'display_errors=On')
         parameters.push('--define', 'log_errors=Off')
         text = textEditor.getText()
-        return helpers.exec(command, parameters, {stdin: text}).then (output) ->
+        [projectPath] = atom.project.relativizePath(filePath)
+        cwd = if projectPath? then projectPath else path.dirname(filePath)
+        return helpers.exec(command, parameters, {stdin: text, cwd: cwd}).then (output) ->
           regex = /^(?:Parse|Fatal) error:\s+(.+) in .+? on line (\d+)/gm
           messages = []
           while((match = regex.exec(output)) isnt null)


### PR DESCRIPTION
This adds support to run project-specific PHP version and fixes #169.

I also added `(?:PHP )?` to the regex since my PHP versions output it this way, not sure if that changed in some PHP version.