### PR TITLE
Clarify settings page scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ section like the following:
   # php path. run 'which php' to find the path
   'executablePath': /usr/bin/php
 ```
+> Additional settings can be found under the supporting package **Linter** automatically installed with linter-php. Global settings like linting delay can be adjusted here.
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ section like the following:
   # php path. run 'which php' to find the path
   'executablePath': /usr/bin/php
 ```
-> Additional settings can be found under the supporting package **Linter** automatically installed with linter-php. Global settings like linting delay can be adjusted here.
+_Additional settings can be found in the consumer of your linter providers, typically this is the [Linter](https://atom.io/packages/linter) package automatically installed with `linter-php`. Global settings like linting delay must be adjusted here._
 
 ## Maintainers
 


### PR DESCRIPTION
Arriving at linter-php directly, I was not aware that a dependency managed most of the settings. After walking through the source code assuming I needed to contribute functionality, I later found these linter settings. I believe others may run into the same confusion, so adding to the readme here. 

Thank you!