### PR TITLE
Fix CI builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,11 @@
 ### Project specific config ###
 install:
+  # Update Chocolatey
+  - choco upgrade chocolatey -y
+  # Enable Windows Update
+  # This is required for one of the dependencies of the Chocolatey PHP package
+  - sc config wuauserv start= auto
+  - net start wuauserv
   # The following installs and sets up PHP
   - cinst -y php
   - cd c:\tools\php

--- a/circle.yml
+++ b/circle.yml
@@ -9,4 +9,4 @@ test:
 
 machine:
   php:
-    version: 5.6.14
+    version: 7.0.7


### PR DESCRIPTION
Fixes a few things in the CI build process:

* Windows Update is required for a few of the required dependencies of the PHP Chocolatey package.
* Tell Chocolatey to update itself to bring in a few bugfixes
* Update CircleCI PHP version