### PR TITLE
Update CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
       php: '7.0'
 
     - os: linux
-      php: '7.0'
+      php: '7.1'
       env:
         - ATOM_CHANNEL=beta
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,23 +13,6 @@ matrix:
       env:
         - ATOM_CHANNEL=beta
 
-    - os: osx
-      language: generic
-      install:
-        # Updating PHP to 5.6.x
-        - curl -s http://php-osx.liip.ch/install.sh | bash -s 5.6
-        - export PATH=/usr/local/php5/bin:$PATH
-
-    - os: osx
-      osx_image: xcode7.3
-      language: generic
-      env:
-        - ATOM_CHANNEL=beta
-      install:
-        # Updating PHP to 7.0.x
-        - curl -s http://php-osx.liip.ch/install.sh | bash -s 7.0
-        - export PATH=/usr/local/php5/bin:$PATH
-
 after_failure:
   - php --syntax-check --define display_errors=On --define log_errors=Off ./spec/files/good.php
   - php --syntax-check --define display_errors=On --define log_errors=Off ./spec/files/bad.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ notifications:
 branches:
   only:
     - master
+    - /^greenkeeper/.*$/
 
 git:
   depth: 10

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,11 +8,11 @@ install:
   - net start wuauserv
   # The following installs and sets up PHP
   - cinst -y php
-  - cd c:\tools\php
+  - cd C:\tools\php71
   - copy php.ini-production php.ini
   - echo date.timezone="UTC" >> php.ini
   - echo extension_dir=ext >> php.ini
-  - SET PATH=C:\tools\php\;%PATH%
+  - SET PATH=C:\tools\php71\;%PATH%
 
 environment:
   matrix:


### PR DESCRIPTION
Update the CI configuration, making the following changes:

* Remove macOS testing due to the queue times making builds insanity inducing.
* Whitelist all Greenkeeper branches
* Update the beta channel to run on PHP v7.1
* Fix the path to PHP on AppVeyor