### PR TITLE
Handle unsaved files

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -89,12 +89,16 @@ export default {
           parameters.push('--define', 'error_reporting=E_ALL');
         }
 
-        const [projectPath] = atom.project.relativizePath(filePath);
         const execOptions = {
           stdin: fileText,
-          cwd: projectPath !== null ? projectPath : dirname(filePath),
           ignoreExitCode: true,
         };
+
+        if (filePath !== null) {
+          // Only specify a CWD if the file has been saved
+          const [projectPath] = atom.project.relativizePath(filePath);
+          execOptions.cwd = projectPath !== null ? projectPath : dirname(filePath);
+        }
 
         const output = await helpers.exec(executablePath, parameters, execOptions);
 


### PR DESCRIPTION
If a file has never been saved it will not have a filePath. If this is the case don't specify a CWD when running PHP.

Fixes #240.