### PR TITLE
Remove check for PHP version

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -7,38 +7,10 @@ import { dirname } from 'path';
 
 // Local variables
 const parseRegex = /^(?:Parse|Fatal) error:\s+(.+) in .+?(?: on line |:)(\d+)/gm;
-const phpCheckCache = new Map();
 
 // Settings
 let executablePath;
 let errorReporting;
-
-const testBin = async () => {
-  if (phpCheckCache.has(executablePath)) {
-    return;
-  }
-  const title = 'linter-php: Unable to determine PHP version';
-  const message = `Unable to determine the version of "${executablePath}` +
-    '", please verify that this is the right path to PHP. If you believe you ' +
-    'have fixed this problem please restart Atom.';
-
-  let output;
-  try {
-    output = await helpers.exec(executablePath, ['-v']);
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error(e);
-    phpCheckCache.set(executablePath, false);
-    atom.notifications.addError(title, { detail: message });
-  }
-
-  const regex = /PHP (\d+)\.(\d+)\.(\d+)/g;
-  if (!regex.exec(output)) {
-    phpCheckCache.set(executablePath, false);
-    atom.notifications.addError(title, { detail: message });
-  }
-  phpCheckCache.set(executablePath, true);
-};
 
 export default {
   activate() {
@@ -48,7 +20,6 @@ export default {
     this.subscriptions.add(
       atom.config.observe('linter-php.executablePath', (value) => {
         executablePath = value;
-        testBin();
       }),
     );
     this.subscriptions.add(
@@ -69,14 +40,6 @@ export default {
       scope: 'file',
       lintOnFly: true,
       lint: async (textEditor) => {
-        if (!phpCheckCache.has(executablePath)) {
-          await testBin();
-        }
-        if (!phpCheckCache.get(executablePath)) {
-          // We don't have a valid PHP version, don't update messages
-          return null;
-        }
-
         const filePath = textEditor.getPath();
         const fileText = textEditor.getText();
 


### PR DESCRIPTION
Removes the check for the version of PHP. It's caused many issues only
related to bugs with the check and not the system setup.

Fixes #231.