### PR TITLE
Update Travis CI for Atom v1.18.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,12 @@ git:
 
 sudo: false
 
+dist: trusty
+
 addons:
   apt:
     packages:
     - build-essential
-    - git
-    - libgnome-keyring-dev
     - fakeroot
+    - git
+    - libsecret-1-dev


### PR DESCRIPTION
Atom v1.18.0 includes a new minimum library version that is only easily satisfied on the Trusty based images.