### PR TITLE
Asyncify specs and utilize activationHooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
   "package-deps": [
     "linter"
   ],
+  "activationHooks": [
+    "language-php:grammar-used"
+  ],
   "scripts": {
     "test": "apm test",
     "lint": "eslint ."

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "devDependencies": {
     "eslint": "^4.3.0",
     "eslint-config-airbnb-base": "^11.3.1",
-    "eslint-plugin-import": "^2.7.0"
+    "eslint-plugin-import": "^2.7.0",
+    "jasmine-fix": "^1.3.0"
   },
   "engines": {
     "atom": ">=1.7.0 <2.0.0"

--- a/spec/.eslintrc.js
+++ b/spec/.eslintrc.js
@@ -2,5 +2,13 @@ module.exports = {
   env: {
     jasmine: true,
     atomtest: true
+  },
+  rules: {
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "devDependencies": true
+      }
+    ]
   }
 };


### PR DESCRIPTION
Use `jasmine-fix` to asyncify the specs, and re-enable the use of `activationHooks`.

Fixes https://github.com/AtomLinter/linter-php/issues/86.