### PR TITLE
Add setting to ignore php.ini

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -41,6 +41,9 @@ export default {
       atom.config.observe('linter-php.errorReporting', (value) => {
         this.errorReporting = value;
       }),
+      atom.config.observe('linter-php.ignorePhpIni', (value) => {
+        this.ignorePhpIni = value;
+      }),
     );
   },
 
@@ -70,6 +73,10 @@ export default {
         ];
         if (this.errorReporting) {
           parameters.push('--define', 'error_reporting=E_ALL');
+        }
+        if (this.ignorePhpIni) {
+          // No configuration (ini) files will be used
+          parameters.push('-n');
         }
 
         const execOptions = {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,12 @@
       "title": "Error Reporting Level Override",
       "description": "Force overriding the `error_reporting` setting from php.ini to `E_ALL` if php.ini is setup to ignore most errors.",
       "default": true
+    },
+    "ignorePhpIni": {
+      "type": "boolean",
+      "title": "Ignore php.ini",
+      "description": "Tell PHP to ignore the php.ini when checking code. This can potentially speed up linting quite a bit, but can also cause PHP to fail to compile your code, breaking linting.",
+      "default": false
     }
   },
   "dependencies": {


### PR DESCRIPTION
Add a setting determining whether to have PHP ignore the php.ini file when linting.

Fixes https://github.com/AtomLinter/linter-php/issues/218.