### PR TITLE
Guard against invalid TextEditors

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -61,6 +61,9 @@ export default {
       scope: 'file',
       lintOnFly: true,
       lint: async (textEditor) => {
+        if (!atom.workspace.isTextEditor(textEditor)) {
+          return null;
+        }
         const filePath = textEditor.getPath();
         const fileText = textEditor.getText();
 
@@ -85,7 +88,7 @@ export default {
           ignoreExitCode: true,
         };
 
-        if (filePath !== null) {
+        if (filePath) {
           // Only specify a CWD if the file has been saved
           const [projectPath] = atom.project.relativizePath(filePath);
           execOptions.cwd = projectPath !== null ? projectPath : path.dirname(filePath);


### PR DESCRIPTION
Add a check that the TextEditor is valid, and fix the check that the path given by it is valid.

Fixes #270.