### PR TITLE
Initial Adoption of Continous Deployment using semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,3 +50,15 @@ addons:
     - fakeroot
     - git
     - libsecret-1-dev
+
+node_js: lts/*
+
+after_success:
+  # Add apm to the PATH
+  - export PATH=${PATH}:${HOME}/atom/usr/bin/
+
+deploy:
+  provider: script
+  skip_cleanup: true
+  script:
+    - npx semantic-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,52 @@
 ### Project specific config ###
 language: php
-matrix:
+os: linux
+env: ATOM_CHANNEL=stable
+script: skip
+
+jobs:
   include:
-    - os: linux
+    - stage: test
       php: '5.6'
-
-    - os: linux
+    - stage: test
       php: '7.0'
-
-    - os: linux
+    - stage: test
       php: '7.1'
-      env:
-        - ATOM_CHANNEL=beta
+    - stage: test
+      php: '7.2'
+      env: ATOM_CHANNEL=beta
+    - stage: test
+      language: node_js
+      node_js: lts/*
+      install:
+        - npm install
+      script:
+        - commitlint-travis
+    - stage: release
+      # Since the deploy needs APM, currently the simplest method is to run
+      # build-package.sh, which requires the specs to pass, so this must run in
+      # the main language instead of Node.js.
+      php: '7.1'
+      script:
+        - export PATH=${PATH}:${HOME}/atom/usr/bin/
+      deploy:
+        provider: script
+        skip_cleanup: true
+        script:
+          - npx semantic-release
 
 after_failure:
   - php --syntax-check --define display_errors=On --define log_errors=Off ./spec/files/good.php
   - php --syntax-check --define display_errors=On --define log_errors=Off ./spec/files/bad.php
 
-before_script:
+before_install:
   - php --version
 
 ### Generic setup follows ###
-script:
+install:
   - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
   - chmod u+x build-package.sh
-  - ./build-package.sh
+  - "./build-package.sh"
 
 notifications:
   email:
@@ -34,7 +56,7 @@ notifications:
 branches:
   only:
     - master
-    - /^greenkeeper/.*$/
+    - "/^greenkeeper/.*$/"
 
 git:
   depth: 10
@@ -46,19 +68,12 @@ dist: trusty
 addons:
   apt:
     packages:
-    - build-essential
-    - fakeroot
-    - git
-    - libsecret-1-dev
+      - build-essential
+      - git
+      - libgnome-keyring-dev
+      - fakeroot
 
-node_js: lts/*
-
-after_success:
-  # Add apm to the PATH
-  - export PATH=${PATH}:${HOME}/atom/usr/bin/
-
-deploy:
-  provider: script
-  skip_cleanup: true
-  script:
-    - npx semantic-release
+stages:
+  - test
+  - name: release
+    if: (NOT type = pull_request) AND branch = master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,11 +8,11 @@ install:
   - net start wuauserv
   # The following installs and sets up PHP
   - cinst -y php
-  - cd C:\tools\php71
+  - cd C:\tools\php72
   - copy php.ini-production php.ini
   - echo date.timezone="UTC" >> php.ini
   - echo extension_dir=ext >> php.ini
-  - SET PATH=C:\tools\php71\;%PATH%
+  - SET PATH=C:\tools\php72\;%PATH%
 
 environment:
   matrix:

--- a/package.json
+++ b/package.json
@@ -29,6 +29,12 @@
     "atom-package-deps": "^4.0.1"
   },
   "devDependencies": {
+    "@commitlint/cli": "^6.1.3",
+    "@commitlint/config-conventional": "^6.1.3",
+    "@commitlint/travis-cli": "^6.1.3",
+    "@semantic-release/apm-config": "^2.0.1",
+    "husky": "^0.14.3",
+    "semantic-release": "^15.1.7",
     "eslint": "^4.6.0",
     "eslint-config-airbnb-base": "^12.0.0",
     "eslint-plugin-import": "^2.7.0",
@@ -44,6 +50,7 @@
     "language-php:grammar-used"
   ],
   "scripts": {
+    "commitmsg": "commitlint -e $GIT_PARAMS",
     "test": "apm test",
     "lint": "eslint ."
   },
@@ -74,5 +81,13 @@
     "globals": {
       "atom": true
     }
+  },
+  "release": {
+    "extends": "@semantic-release/apm-config"
+  },
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "main": "./lib/main.js",
   "version": "1.5.1",
   "description": "Lint PHP on the fly, using php -l",
-  "repository": "https://github.com/AtomLinter/linter-php",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AtomLinter/linter-php.git"
+  },
   "license": "MIT",
   "configSchema": {
     "executablePath": {


### PR DESCRIPTION
To ease the modification/contribution to publish pipeline there has been some discussion of adopting a continuous deployment system for AtomLinter packages. To accomplish this we are making use of [`semantic-release`](https://github.com/semantic-release/semantic-release) and [`@semantic-release/apm-config`](https://github.com/semantic-release/apm-config).

This pull request has been [dynamically created using a script](https://gist.github.com/keplersj/8bc7622ea741c0964d12842bfc679c5d). While the result is not perfect, it does accompish most of the grunt work of adopting continous deployment. There is some reconciliation that needs to be done before this can be merged.

Among the things needed to be reconciled, an [APM Token](https://atom.io/account) and [GitHub Token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) will need to be added to this repo's continous integration (most likely [Travis CI](https://docs.travis-ci.com/user/environment-variables#Defining-Variables-in-Repository-Settings)) configuration for automated deployments to work.

Again, this Pull Request has been created by a script made by @keplersj. Please mention him if something has gone wrong, and he'll be happy to help.

ref: AtomLinter/Meta#18

cc: @Arcanemagus
