### PR TITLE
Don't install language-puppet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,6 @@ defaults: &defaults
   working_directory: /tmp/project
   docker:
     - image: arcanemagus/atom-docker-ci:stable
-  environment:
-    APM_TEST_PACKAGES: "language-puppet"
   steps:
     # Restore project state
     - attach_workspace:


### PR DESCRIPTION
An artifact from copying over from a different project's configuration that accidentally got left in.