### PR TITLE
Update to Linter v2 API

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -59,7 +59,7 @@ export default {
       name: 'PHP',
       grammarScopes: ['text.html.php', 'source.php'],
       scope: 'file',
-      lintOnFly: true,
+      lintsOnChange: true,
       lint: async (textEditor) => {
         if (!atom.workspace.isTextEditor(textEditor)) {
           return null;
@@ -106,12 +106,16 @@ export default {
         while (match !== null) {
           const line = Number.parseInt(match[3], 10) - 1;
           const errorType = match[1];
+
           messages.push({
-            type: (/error/i.test(errorType) ? 'Error' : 'Warning'),
-            filePath,
-            range: helpers.generateRange(textEditor, line),
-            text: match[2],
+            severity: (/error/i.test(errorType) ? 'error' : 'warning'),
+            location: {
+              file: filePath,
+              position: helpers.generateRange(textEditor, line),
+            },
+            excerpt: match[2],
           });
+
           match = parseRegex.exec(output);
         }
         return messages;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "atom-linter": "^10.0.0",
-    "atom-package-deps": "^4.0.1"
+    "atom-package-deps": "^5.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.3.2",
@@ -47,7 +47,7 @@
     "atom": ">=1.7.0 <2.0.0"
   },
   "package-deps": [
-    "linter"
+    "linter:2.0.0"
   ],
   "activationHooks": [
     "language-php:grammar-used"
@@ -64,7 +64,7 @@
   "providedServices": {
     "linter": {
       "versions": {
-        "1.0.0": "provideLinter"
+        "2.0.0": "provideLinter"
       }
     }
   },

--- a/spec/linter-php-spec.js
+++ b/spec/linter-php-spec.js
@@ -39,11 +39,11 @@ describe('The php -l provider for Linter', () => {
       const messages = await lint(editor);
 
       expect(messages.length).toBe(1);
-      expect(messages[0].type).toBe('Error');
-      expect(messages[0].html).not.toBeDefined();
-      expect(messages[0].text).toBe('syntax error, unexpected \'{\'');
-      expect(messages[0].filePath).toBe(badPath);
-      expect(messages[0].range).toEqual([[1, 0], [1, 6]]);
+      expect(messages[0].severity).toBe('error');
+      expect(messages[0].description).not.toBeDefined();
+      expect(messages[0].excerpt).toBe('syntax error, unexpected \'{\'');
+      expect(messages[0].location.file).toBe(badPath);
+      expect(messages[0].location.position).toEqual([[1, 0], [1, 6]]);
     });
   });
 
@@ -65,10 +65,10 @@ describe('The php -l provider for Linter', () => {
     const editor = await atom.workspace.open(fatalPath);
     const messages = await lint(editor);
 
-    expect(messages[0].type).toBe('Error');
-    expect(messages[0].text).toBe('Cannot redeclare Test\\A::foo()');
-    expect(messages[0].filePath).toBe(fatalPath);
-    expect(messages[0].range).toEqual([[10, 4], [10, 25]]);
+    expect(messages[0].severity).toBe('error');
+    expect(messages[0].excerpt).toBe('Cannot redeclare Test\\A::foo()');
+    expect(messages[0].location.file).toBe(fatalPath);
+    expect(messages[0].location.position).toEqual([[10, 4], [10, 25]]);
   });
 
   it('handles deprecated errors', async () => {
@@ -79,10 +79,10 @@ describe('The php -l provider for Linter', () => {
     expect(phpVersionInfo.major).not.toBeLessThan(5);
 
     if (phpVersionInfo.major >= 7) {
-      expect(messages[0].type).toBe('Warning');
-      expect(messages[0].filePath).toBe(deprecatedPath);
-      expect(messages[0].text).toBe('Methods with the same name as their class will not be constructors in a future version of PHP; Foo has a deprecated constructor');
-      expect(messages[0].range).toEqual([[3, 0], [3, 9]]);
+      expect(messages[0].severity).toBe('warning');
+      expect(messages[0].excerpt).toBe('Methods with the same name as their class will not be constructors in a future version of PHP; Foo has a deprecated constructor');
+      expect(messages[0].location.file).toBe(deprecatedPath);
+      expect(messages[0].location.position).toEqual([[3, 0], [3, 9]]);
     } else if (phpVersionInfo.major === 5) {
       // No E_DEPRECATED errors are reported by the linter for 5.x
     }


### PR DESCRIPTION
Update to the v2 Linter API, allowing usage with newer consumers of the Linter service.

Fixes #302.