### PR TITLE
Fix AppVeyor PHP path

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,11 +8,11 @@ install:
   - net start wuauserv
   # The following installs and sets up PHP
   - cinst -y php
-  - cd C:\tools\php72
+  - cd C:\tools\php73
+  - SET PATH=C:\tools\php73\;%PATH%
   - copy php.ini-production php.ini
   - echo date.timezone="UTC" >> php.ini
   - echo extension_dir=ext >> php.ini
-  - SET PATH=C:\tools\php72\;%PATH%
 
 environment:
   matrix:


### PR DESCRIPTION
The path that PHP is installed to under AppVeyor has been changed to `C:\tools\php73`.