### PR TITLE
Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1137,15 +1137,15 @@
       }
     },
     "acorn": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
-      "integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
-      "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
       "dev": true
     },
     "agent-base": {
@@ -1460,12 +1460,12 @@
       "dev": true
     },
     "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "^3.1.0"
       }
     },
     "cli-table": {
@@ -1958,9 +1958,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.4.0.tgz",
-      "integrity": "sha512-WTVEzK3lSFoXUovDHEbkJqCVPEPwbhCq4trDktNI6ygs7aO41d4cDT0JFAT5MivzZeVLWlg7vHL+bgrQv/t3vA==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.6.0.tgz",
+      "integrity": "sha512-PpEBq7b6qY/qrOmpYQ/jTMDYfuQMELR4g4WI1M/NaSDDD/bdcMb+dj4Hgks7p41kW2caXsPsEZAEAyAgjVVC0g==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1970,9 +1970,9 @@
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "eslint-scope": "^5.0.0",
-        "eslint-utils": "^1.4.2",
+        "eslint-utils": "^1.4.3",
         "eslint-visitor-keys": "^1.1.0",
-        "espree": "^6.1.1",
+        "espree": "^6.1.2",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
@@ -1982,7 +1982,7 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^6.4.1",
+        "inquirer": "^7.0.0",
         "is-glob": "^4.0.0",
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -2002,26 +2002,6 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
-        "glob-parent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-          "integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.1"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-              "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-              "dev": true,
-              "requires": {
-                "is-extglob": "^2.1.1"
-              }
-            }
-          }
-        },
         "import-fresh": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
@@ -2031,12 +2011,6 @@
             "parent-module": "^1.0.0",
             "resolve-from": "^4.0.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
         },
         "semver": {
           "version": "6.3.0",
@@ -2240,12 +2214,12 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
@@ -2255,13 +2229,13 @@
       "dev": true
     },
     "espree": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-      "integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+      "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
       "dev": true,
       "requires": {
-        "acorn": "^7.0.0",
-        "acorn-jsx": "^5.0.2",
+        "acorn": "^7.1.0",
+        "acorn-jsx": "^5.1.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
@@ -2993,26 +2967,35 @@
       "dev": true
     },
     "inquirer": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
-      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
+      "integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.2.0",
+        "ansi-escapes": "^4.2.1",
         "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
+        "cli-cursor": "^3.1.0",
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.12",
-        "mute-stream": "0.0.7",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
         "run-async": "^2.2.0",
         "rxjs": "^6.4.0",
-        "string-width": "^2.1.0",
+        "string-width": "^4.1.0",
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+          "integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.5.2"
+          }
+        },
         "chalk": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -3024,10 +3007,19 @@
             "supports-color": "^5.3.0"
           }
         },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+        "figures": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
+          "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "type-fest": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+          "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
           "dev": true
         }
       }
@@ -3088,9 +3080,9 @@
       "dev": true
     },
     "is-glob": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
@@ -3503,9 +3495,9 @@
       "dev": true
     },
     "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
     "minimatch": {
@@ -3563,9 +3555,9 @@
       "dev": true
     },
     "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
     "named-js-regexp": {
@@ -7185,12 +7177,12 @@
       }
     },
     "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "^2.1.0"
       }
     },
     "opencollective-postinstall": {
@@ -7593,12 +7585,12 @@
       }
     },
     "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
+        "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
     },
@@ -8161,29 +8153,27 @@
       }
     },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
+      "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^5.2.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
           "dev": true
         },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
         }
       }
     },
@@ -8282,12 +8272,6 @@
         "string-width": "^3.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
-        },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2745,20 +2745,20 @@
       "dev": true
     },
     "husky": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-3.0.5.tgz",
-      "integrity": "sha512-cKd09Jy9cDyNIvAdN2QQAP/oA21sle4FWXjIMDttailpLAYZuBE7WaPmhrkj+afS8Sj9isghAtFvWSQ0JiwOHg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-3.0.9.tgz",
+      "integrity": "sha512-Yolhupm7le2/MqC1VYLk/cNmYxsSsqKkTyBhzQHhPK1jFnC89mmmNVuGtLNabjDI6Aj8UNIr0KpRNuBkiC4+sg==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
+        "ci-info": "^2.0.0",
         "cosmiconfig": "^5.2.1",
         "execa": "^1.0.0",
         "get-stdin": "^7.0.0",
-        "is-ci": "^2.0.0",
         "opencollective-postinstall": "^2.0.2",
         "pkg-dir": "^4.2.0",
         "please-upgrade-node": "^3.2.0",
-        "read-pkg": "^5.1.1",
+        "read-pkg": "^5.2.0",
         "run-node": "^1.0.0",
         "slash": "^3.0.0"
       },
@@ -2809,15 +2809,6 @@
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
           }
         },
         "locate-path": {
@@ -2905,18 +2896,6 @@
               }
             }
           }
-        },
-        "slash": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-          "dev": true
-        },
-        "type-fest": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-          "dev": true
         }
       }
     },
@@ -3083,15 +3062,6 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
-    },
-    "is-ci": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-      "dev": true,
-      "requires": {
-        "ci-info": "^2.0.0"
-      }
     },
     "is-date-object": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -360,49 +360,51 @@
       }
     },
     "@nodelib/fs.scandir": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.2.tgz",
-      "integrity": "sha512-wrIBsjA5pl13f0RN4Zx4FNWmU71lv03meGKnqRUoCyan17s4V3WL92f3w3AIuWbNnpcrQyFBU5qMavJoB8d27w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
       "dev": true,
       "requires": {
-        "@nodelib/fs.stat": "2.0.2",
+        "@nodelib/fs.stat": "2.0.3",
         "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.2.tgz",
-      "integrity": "sha512-z8+wGWV2dgUhLqrtRYa03yDx4HWMvXKi1z8g3m2JyxAx8F7xk74asqPk5LAETjqDSGLFML/6CDl0+yFunSYicw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
       "dev": true
     },
     "@nodelib/fs.walk": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.3.tgz",
-      "integrity": "sha512-l6t8xEhfK9Sa4YO5mIRdau7XSOADfmh3jCr0evNHdY+HNkW6xuQhgMH7D73VV6WpZOagrW0UludvMTiifiwTfA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
       "dev": true,
       "requires": {
-        "@nodelib/fs.scandir": "2.1.2",
+        "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
       }
     },
     "@octokit/endpoint": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.3.5.tgz",
-      "integrity": "sha512-f8KqzIrnzPLiezDsZZPB+K8v8YSv6aKFl7eOu59O46lmlW4HagWl1U6NWl6LmT8d1w7NsKBI3paVtzcnRGO1gw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.0.tgz",
+      "integrity": "sha512-TXYS6zXeBImNB9BVj+LneMDqXX+H0exkOpyXobvp92O3B1348QsKnNioISFKgOMsb3ibZvQGwCdpiwQd3KAjIA==",
       "dev": true,
       "requires": {
+        "@octokit/types": "^1.0.0",
         "is-plain-object": "^3.0.0",
         "universal-user-agent": "^4.0.0"
       }
     },
     "@octokit/request": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.1.0.tgz",
-      "integrity": "sha512-I15T9PwjFs4tbWyhtFU2Kq7WDPidYMvRB7spmxoQRZfxSmiqullG+Nz+KbSmpkfnlvHwTr1e31R5WReFRKMXjg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.0.tgz",
+      "integrity": "sha512-mMIeNrtYyNEIYNsKivDyUAukBkw0M5ckyJX56xoFRXSasDPCloIXaQOnaKNopzQ8dIOvpdq1ma8gmrS+h6O2OQ==",
       "dev": true,
       "requires": {
-        "@octokit/endpoint": "^5.1.0",
+        "@octokit/endpoint": "^5.5.0",
         "@octokit/request-error": "^1.0.1",
+        "@octokit/types": "^1.0.0",
         "deprecation": "^2.0.0",
         "is-plain-object": "^3.0.0",
         "node-fetch": "^2.3.0",
@@ -421,12 +423,12 @@
       }
     },
     "@octokit/rest": {
-      "version": "16.28.9",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.28.9.tgz",
-      "integrity": "sha512-IKGnX+Tvzt7XHhs8f4ajqxyJvYAMNX5nWfoJm4CQj8LZToMiaJgutf5KxxpxoC3y5w7JTJpW5rnWnF4TsIvCLA==",
+      "version": "16.34.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.34.0.tgz",
+      "integrity": "sha512-EBe5qMQQOZRuezahWCXCnSe0J6tAqrW2hrEH9U8esXzKor1+HUDf8jgImaZf5lkTyWCQA296x9kAH5c0pxEgVQ==",
       "dev": true,
       "requires": {
-        "@octokit/request": "^5.0.0",
+        "@octokit/request": "^5.2.0",
         "@octokit/request-error": "^1.0.2",
         "atob-lite": "^2.0.0",
         "before-after-hook": "^2.0.0",
@@ -440,32 +442,36 @@
         "universal-user-agent": "^4.0.0"
       }
     },
+    "@octokit/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-t4ZD74UnNVMq6kZBDZceflRKK3q4o5PoCKMAGht0RK84W57tqonqKL3vCxJHtbGExdan9RwV8r7VJBZxIM1O7Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^12.11.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.11.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.7.tgz",
+          "integrity": "sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA==",
+          "dev": true
+        }
+      }
+    },
     "@semantic-release/apm": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/apm/-/apm-1.0.1.tgz",
-      "integrity": "sha512-d5oHFO8OHqy9rIsfkrPVJlgmmeqT2+f9U1i4Zv9vtVcJMBs4+yFvCjVn4AMblp/qcq9xb5GspWR5fPz/Y2UolA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@semantic-release/apm/-/apm-1.0.5.tgz",
+      "integrity": "sha512-TxH/P3gSyYsv1KyiLfoJTKgP/KgouCX4Q7FViUnOQTCUBeT7J81dGAX0oO12gD9+HEBCLbGOaZ/1yVpCLzVxxQ==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^2.2.0",
-        "aggregate-error": "^2.0.0",
+        "aggregate-error": "^3.0.0",
         "execa": "^1.0.0",
         "npm": "^6.4.1",
-        "read-pkg": "^4.0.1"
+        "read-pkg": "^5.0.0"
       },
       "dependencies": {
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "dev": true,
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
         "execa": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -481,32 +487,48 @@
             "strip-eof": "^1.0.0"
           }
         },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
           "dev": true,
           "requires": {
-            "pump": "^3.0.0"
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
           }
         },
         "read-pkg": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
-          "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
           "dev": true,
           "requires": {
-            "normalize-package-data": "^2.3.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0"
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
           }
         }
       }
     },
     "@semantic-release/apm-config": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/apm-config/-/apm-config-6.0.1.tgz",
-      "integrity": "sha512-YTGmd4WQOXlHmKd2tuLpumSY23/IN9JeL8QmWYXLUYy5xExNF365r91Nu02B24ljaSmU16qc4M36/FO16w2pnw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/apm-config/-/apm-config-6.0.2.tgz",
+      "integrity": "sha512-MNEDD47LksKZmMmKm7RjTi85E4PnRnMtMfBm2ekJZQkMenEmk9ttahd7xK0PFqoArDvh37FNSTZF3TlTKkHYDw==",
       "dev": true,
       "requires": {
         "@semantic-release/apm": "^1.0.0",
@@ -518,35 +540,35 @@
       }
     },
     "@semantic-release/changelog": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-3.0.2.tgz",
-      "integrity": "sha512-pDUaBNAuPAqQ+ArHwvR160RG2LbfyIVz9EJXgxH0V547rlx/hCs0Sp7L4Rtzi5Z+d6CHcv9g2ynxplE1xAzp2g==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-3.0.5.tgz",
+      "integrity": "sha512-/U44eK5qL2olevbEi+GrJxq1lNGUABChqK58A3SkiDsZS6AoGO8CJHQ7OG0zx+spxwkY4TevZ85Whz/hYyO+5w==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^2.1.0",
-        "aggregate-error": "^2.0.0",
-        "fs-extra": "^7.0.0",
+        "aggregate-error": "^3.0.0",
+        "fs-extra": "^8.0.0",
         "lodash": "^4.17.4"
       }
     },
     "@semantic-release/commit-analyzer": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-6.1.0.tgz",
-      "integrity": "sha512-2lb+t6muGenI86mYGpZYOgITx9L3oZYF697tJoqXeQEk0uw0fm+OkkOuDTBA3Oax9ftoNIrCKv9bwgYvxrbM6w==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-6.3.1.tgz",
+      "integrity": "sha512-TQj/BU48b6dy1jS4yJ2Vfd7vOwkNWM/ySuISvW97yeQDd8Lm++t/NUlLdsn6+IZmtGZGMwsfGHYBZSLMuRZmQQ==",
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "^5.0.0",
         "conventional-commits-filter": "^2.0.0",
         "conventional-commits-parser": "^3.0.0",
         "debug": "^4.0.0",
-        "import-from": "^2.1.0",
+        "import-from": "^3.0.0",
         "lodash": "^4.17.4"
       },
       "dependencies": {
         "conventional-changelog-angular": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.2.tgz",
-          "integrity": "sha512-yx7m7lVrXmt4nKWQgWZqxSALEiAKZhOAcbxdUaU9575mB0CzXVbgrgpfSnSP7OqWDUTYGD0YVJ0MSRdyOPgAwA==",
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.5.tgz",
+          "integrity": "sha512-RrkdWnL/TVyWV1ayWmSsrWorsTDqjL/VwG5ZSEneBQrd65ONcfeA1cW7FLtNweQyMiKOyriCMTKRSlk18DjTrw==",
           "dev": true,
           "requires": {
             "compare-func": "^1.3.1",
@@ -554,18 +576,27 @@
           }
         },
         "conventional-commits-parser": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.1.tgz",
-          "integrity": "sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==",
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.5.tgz",
+          "integrity": "sha512-qVz9+5JwdJzsbt7JbJ6P7NOXBGt8CyLFJYSjKAuPSgO+5UGfcsbk9EMR+lI8Unlvx6qwIc2YDJlrGIfay2ehNA==",
           "dev": true,
           "requires": {
             "JSONStream": "^1.0.4",
-            "is-text-path": "^1.0.0",
+            "is-text-path": "^2.0.0",
             "lodash": "^4.2.1",
             "meow": "^4.0.0",
             "split2": "^2.0.0",
-            "through2": "^2.0.0",
+            "through2": "^3.0.0",
             "trim-off-newlines": "^1.0.0"
+          }
+        },
+        "is-text-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
+          "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
+          "dev": true,
+          "requires": {
+            "text-extensions": "^2.0.0"
           }
         },
         "meow": {
@@ -583,6 +614,21 @@
             "read-pkg-up": "^3.0.0",
             "redent": "^2.0.0",
             "trim-newlines": "^2.0.0"
+          }
+        },
+        "text-extensions": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.0.0.tgz",
+          "integrity": "sha512-F91ZqLgvi1E0PdvmxMgp+gcf6q8fMH7mhdwWfzXnl1k+GbpQDmi8l7DzLC5JTASKbwpY3TfxajAUzAXcv2NmsQ==",
+          "dev": true
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2 || 3"
           }
         }
       }
@@ -611,16 +657,6 @@
         "p-reduce": "^2.0.0"
       },
       "dependencies": {
-        "aggregate-error": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.0.tgz",
-          "integrity": "sha512-yKD9kEoJIR+2IFqhMwayIBgheLYbB3PS2OBhWae1L/ODTd/JF/30cW0bc9TqzRL3k4U41Dieu3BF4I29p8xesA==",
-          "dev": true,
-          "requires": {
-            "clean-stack": "^2.0.0",
-            "indent-string": "^3.2.0"
-          }
-        },
         "execa": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -635,30 +671,13 @@
             "signal-exit": "^3.0.0",
             "strip-eof": "^1.0.0"
           }
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
-          "dev": true
         }
       }
     },
     "@semantic-release/github": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-5.4.4.tgz",
-      "integrity": "sha512-+KheVeE3pPdywdIByQ4gHLIyptqhzGmWTiHdRwFURGKvlnK7DB0pceZKEMdYVOdZZUvVbzg5mKY5EuFZ5cFgUQ==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-5.5.4.tgz",
+      "integrity": "sha512-CovZ9zs/rbBOCyyzmstoCwGS5qNEgab3wB8y3SAvOD7TfhtqizWVRkUJV7nzzaevomhUSZD/lp7Cs/fk1sE1Qw==",
       "dev": true,
       "requires": {
         "@octokit/rest": "^16.27.0",
@@ -670,54 +689,24 @@
         "fs-extra": "^8.0.0",
         "globby": "^10.0.0",
         "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^2.2.1",
-        "issue-parser": "^4.0.0",
+        "https-proxy-agent": "^3.0.0",
+        "issue-parser": "^5.0.0",
         "lodash": "^4.17.4",
         "mime": "^2.4.3",
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
-        "parse-github-url": "^1.0.1",
         "url-join": "^4.0.0"
-      },
-      "dependencies": {
-        "aggregate-error": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.0.tgz",
-          "integrity": "sha512-yKD9kEoJIR+2IFqhMwayIBgheLYbB3PS2OBhWae1L/ODTd/JF/30cW0bc9TqzRL3k4U41Dieu3BF4I29p8xesA==",
-          "dev": true,
-          "requires": {
-            "clean-stack": "^2.0.0",
-            "indent-string": "^3.2.0"
-          }
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
-          "dev": true
-        }
       }
     },
     "@semantic-release/npm": {
-      "version": "5.1.15",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-5.1.15.tgz",
-      "integrity": "sha512-MUUKOOtqsX/aJZJIjiAdw7SkCH+D3De060l1HhTlqrwTB7PzMtXcUMen6Prd1Hv8+gknUFkSWhVmi8tIaGDVnA==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-5.3.1.tgz",
+      "integrity": "sha512-uHMU0g/HsnDSJRNIj52MX/frNxbtYtmW/TJXtLC13sx+GLjGRGUc+vMwYqPovY1gEk6UmDTGEi31C9POpO9dLQ==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^2.2.0",
         "aggregate-error": "^3.0.0",
-        "execa": "^2.0.2",
+        "execa": "^3.2.0",
         "fs-extra": "^8.0.0",
         "lodash": "^4.17.15",
         "nerf-dart": "^1.0.0",
@@ -725,45 +714,37 @@
         "npm": "^6.10.3",
         "rc": "^1.2.8",
         "read-pkg": "^5.0.0",
-        "registry-auth-token": "^4.0.0"
+        "registry-auth-token": "^4.0.0",
+        "tempy": "^0.3.0"
       },
       "dependencies": {
-        "aggregate-error": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.0.tgz",
-          "integrity": "sha512-yKD9kEoJIR+2IFqhMwayIBgheLYbB3PS2OBhWae1L/ODTd/JF/30cW0bc9TqzRL3k4U41Dieu3BF4I29p8xesA==",
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
           "dev": true,
           "requires": {
-            "clean-stack": "^2.0.0",
-            "indent-string": "^3.2.0"
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
           }
         },
         "execa": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-2.0.4.tgz",
-          "integrity": "sha512-VcQfhuGD51vQUQtKIq2fjGDLDbL6N1DTQVpYzxZ7LPIXw3HqTuIz6uxRmpV1qf8i31LHf2kjiaGI+GdHwRgbnQ==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-3.2.0.tgz",
+          "integrity": "sha512-kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==",
           "dev": true,
           "requires": {
-            "cross-spawn": "^6.0.5",
+            "cross-spawn": "^7.0.0",
             "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
             "is-stream": "^2.0.0",
             "merge-stream": "^2.0.0",
-            "npm-run-path": "^3.0.0",
+            "npm-run-path": "^4.0.0",
             "onetime": "^5.1.0",
             "p-finally": "^2.0.0",
             "signal-exit": "^3.0.2",
             "strip-final-newline": "^2.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
           }
         },
         "get-stream": {
@@ -775,22 +756,10 @@
             "pump": "^3.0.0"
           }
         },
-        "graceful-fs": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
-          "dev": true
-        },
         "is-stream": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         },
         "mimic-fn": {
@@ -811,3489 +780,10 @@
             "validate-npm-package-license": "^3.0.1"
           }
         },
-        "npm": {
-          "version": "6.11.3",
-          "resolved": "https://registry.npmjs.org/npm/-/npm-6.11.3.tgz",
-          "integrity": "sha512-K2h+MPzZiY39Xf6eHEdECe/LKoJXam4UCflz5kIxoskN3LQFeYs5fqBGT5i4TtM/aBk+86Mcf+jgXs/WuWAutQ==",
-          "dev": true,
-          "requires": {
-            "JSONStream": "^1.3.5",
-            "abbrev": "~1.1.1",
-            "ansicolors": "~0.3.2",
-            "ansistyles": "~0.1.3",
-            "aproba": "^2.0.0",
-            "archy": "~1.0.0",
-            "bin-links": "^1.1.3",
-            "bluebird": "^3.5.5",
-            "byte-size": "^5.0.1",
-            "cacache": "^12.0.3",
-            "call-limit": "^1.1.1",
-            "chownr": "^1.1.2",
-            "ci-info": "^2.0.0",
-            "cli-columns": "^3.1.2",
-            "cli-table3": "^0.5.1",
-            "cmd-shim": "^3.0.3",
-            "columnify": "~1.5.4",
-            "config-chain": "^1.1.12",
-            "debuglog": "*",
-            "detect-indent": "~5.0.0",
-            "detect-newline": "^2.1.0",
-            "dezalgo": "~1.0.3",
-            "editor": "~1.0.0",
-            "figgy-pudding": "^3.5.1",
-            "find-npm-prefix": "^1.0.2",
-            "fs-vacuum": "~1.2.10",
-            "fs-write-stream-atomic": "~1.0.10",
-            "gentle-fs": "^2.2.1",
-            "glob": "^7.1.4",
-            "graceful-fs": "^4.2.2",
-            "has-unicode": "~2.0.1",
-            "hosted-git-info": "^2.8.2",
-            "iferr": "^1.0.2",
-            "imurmurhash": "*",
-            "infer-owner": "^1.0.4",
-            "inflight": "~1.0.6",
-            "inherits": "^2.0.4",
-            "ini": "^1.3.5",
-            "init-package-json": "^1.10.3",
-            "is-cidr": "^3.0.0",
-            "json-parse-better-errors": "^1.0.2",
-            "lazy-property": "~1.0.0",
-            "libcipm": "^4.0.3",
-            "libnpm": "^3.0.1",
-            "libnpmaccess": "^3.0.2",
-            "libnpmhook": "^5.0.3",
-            "libnpmorg": "^1.0.1",
-            "libnpmsearch": "^2.0.2",
-            "libnpmteam": "^1.0.2",
-            "libnpx": "^10.2.0",
-            "lock-verify": "^2.1.0",
-            "lockfile": "^1.0.4",
-            "lodash._baseindexof": "*",
-            "lodash._baseuniq": "~4.6.0",
-            "lodash._bindcallback": "*",
-            "lodash._cacheindexof": "*",
-            "lodash._createcache": "*",
-            "lodash._getnative": "*",
-            "lodash.clonedeep": "~4.5.0",
-            "lodash.restparam": "*",
-            "lodash.union": "~4.6.0",
-            "lodash.uniq": "~4.5.0",
-            "lodash.without": "~4.4.0",
-            "lru-cache": "^5.1.1",
-            "meant": "~1.0.1",
-            "mississippi": "^3.0.0",
-            "mkdirp": "~0.5.1",
-            "move-concurrently": "^1.0.1",
-            "node-gyp": "^5.0.3",
-            "nopt": "~4.0.1",
-            "normalize-package-data": "^2.5.0",
-            "npm-audit-report": "^1.3.2",
-            "npm-cache-filename": "~1.0.2",
-            "npm-install-checks": "~3.0.0",
-            "npm-lifecycle": "^3.1.3",
-            "npm-package-arg": "^6.1.1",
-            "npm-packlist": "^1.4.4",
-            "npm-pick-manifest": "^3.0.2",
-            "npm-profile": "^4.0.2",
-            "npm-registry-fetch": "^4.0.0",
-            "npm-user-validate": "~1.0.0",
-            "npmlog": "~4.1.2",
-            "once": "~1.4.0",
-            "opener": "^1.5.1",
-            "osenv": "^0.1.5",
-            "pacote": "^9.5.8",
-            "path-is-inside": "~1.0.2",
-            "promise-inflight": "~1.0.1",
-            "qrcode-terminal": "^0.12.0",
-            "query-string": "^6.8.2",
-            "qw": "~1.0.1",
-            "read": "~1.0.7",
-            "read-cmd-shim": "^1.0.4",
-            "read-installed": "~4.0.3",
-            "read-package-json": "^2.1.0",
-            "read-package-tree": "^5.3.1",
-            "readable-stream": "^3.4.0",
-            "readdir-scoped-modules": "^1.1.0",
-            "request": "^2.88.0",
-            "retry": "^0.12.0",
-            "rimraf": "^2.6.3",
-            "safe-buffer": "^5.1.2",
-            "semver": "^5.7.1",
-            "sha": "^3.0.0",
-            "slide": "~1.1.6",
-            "sorted-object": "~2.0.1",
-            "sorted-union-stream": "~2.1.3",
-            "ssri": "^6.0.1",
-            "stringify-package": "^1.0.0",
-            "tar": "^4.4.10",
-            "text-table": "~0.2.0",
-            "tiny-relative-date": "^1.3.0",
-            "uid-number": "0.0.6",
-            "umask": "~1.1.0",
-            "unique-filename": "^1.1.1",
-            "unpipe": "~1.0.0",
-            "update-notifier": "^2.5.0",
-            "uuid": "^3.3.2",
-            "validate-npm-package-license": "^3.0.4",
-            "validate-npm-package-name": "~3.0.0",
-            "which": "^1.3.1",
-            "worker-farm": "^1.7.0",
-            "write-file-atomic": "^2.4.3"
-          },
-          "dependencies": {
-            "JSONStream": {
-              "version": "1.3.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "jsonparse": "^1.2.0",
-                "through": ">=2.2.7 <3"
-              }
-            },
-            "abbrev": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "agent-base": {
-              "version": "4.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "es6-promisify": "^5.0.0"
-              }
-            },
-            "agentkeepalive": {
-              "version": "3.5.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "humanize-ms": "^1.2.1"
-              }
-            },
-            "ajv": {
-              "version": "5.5.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
-              }
-            },
-            "ansi-align": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "string-width": "^2.0.0"
-              }
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "ansi-styles": {
-              "version": "3.2.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "color-convert": "^1.9.0"
-              }
-            },
-            "ansicolors": {
-              "version": "0.3.2",
-              "bundled": true,
-              "dev": true
-            },
-            "ansistyles": {
-              "version": "0.1.3",
-              "bundled": true,
-              "dev": true
-            },
-            "aproba": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "archy": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "are-we-there-yet": {
-              "version": "1.1.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.3.6",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.3",
-                    "isarray": "~1.0.0",
-                    "process-nextick-args": "~2.0.0",
-                    "safe-buffer": "~5.1.1",
-                    "string_decoder": "~1.1.1",
-                    "util-deprecate": "~1.0.1"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                }
-              }
-            },
-            "asap": {
-              "version": "2.0.6",
-              "bundled": true,
-              "dev": true
-            },
-            "asn1": {
-              "version": "0.2.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safer-buffer": "~2.1.0"
-              }
-            },
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true,
-              "dev": true
-            },
-            "aws-sign2": {
-              "version": "0.7.0",
-              "bundled": true,
-              "dev": true
-            },
-            "aws4": {
-              "version": "1.8.0",
-              "bundled": true,
-              "dev": true
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "^0.14.3"
-              }
-            },
-            "bin-links": {
-              "version": "1.1.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "bluebird": "^3.5.3",
-                "cmd-shim": "^3.0.0",
-                "gentle-fs": "^2.0.1",
-                "graceful-fs": "^4.1.15",
-                "write-file-atomic": "^2.3.0"
-              }
-            },
-            "bluebird": {
-              "version": "3.5.5",
-              "bundled": true,
-              "dev": true
-            },
-            "boxen": {
-              "version": "1.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-align": "^2.0.0",
-                "camelcase": "^4.0.0",
-                "chalk": "^2.0.1",
-                "cli-boxes": "^1.0.0",
-                "string-width": "^2.0.0",
-                "term-size": "^1.2.0",
-                "widest-line": "^2.0.0"
-              }
-            },
-            "brace-expansion": {
-              "version": "1.1.11",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "buffer-from": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "builtins": {
-              "version": "1.0.3",
-              "bundled": true,
-              "dev": true
-            },
-            "byline": {
-              "version": "5.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "byte-size": {
-              "version": "5.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "cacache": {
-              "version": "12.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "bluebird": "^3.5.5",
-                "chownr": "^1.1.1",
-                "figgy-pudding": "^3.5.1",
-                "glob": "^7.1.4",
-                "graceful-fs": "^4.1.15",
-                "infer-owner": "^1.0.3",
-                "lru-cache": "^5.1.1",
-                "mississippi": "^3.0.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.3",
-                "ssri": "^6.0.1",
-                "unique-filename": "^1.1.1",
-                "y18n": "^4.0.0"
-              }
-            },
-            "call-limit": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "camelcase": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "capture-stack-trace": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true,
-              "dev": true
-            },
-            "chalk": {
-              "version": "2.4.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            },
-            "chownr": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "ci-info": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "cidr-regex": {
-              "version": "2.0.10",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ip-regex": "^2.1.0"
-              }
-            },
-            "cli-boxes": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "cli-columns": {
-              "version": "3.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "string-width": "^2.0.0",
-                "strip-ansi": "^3.0.1"
-              }
-            },
-            "cli-table3": {
-              "version": "0.5.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "colors": "^1.1.2",
-                "object-assign": "^4.1.0",
-                "string-width": "^2.1.1"
-              }
-            },
-            "cliui": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "3.0.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "strip-ansi": {
-                  "version": "4.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "ansi-regex": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "clone": {
-              "version": "1.0.4",
-              "bundled": true,
-              "dev": true
-            },
-            "cmd-shim": {
-              "version": "3.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "mkdirp": "~0.5.0"
-              }
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true,
-              "dev": true
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "color-convert": {
-              "version": "1.9.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "color-name": "^1.1.1"
-              }
-            },
-            "color-name": {
-              "version": "1.1.3",
-              "bundled": true,
-              "dev": true
-            },
-            "colors": {
-              "version": "1.3.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "columnify": {
-              "version": "1.5.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "strip-ansi": "^3.0.0",
-                "wcwidth": "^1.0.0"
-              }
-            },
-            "combined-stream": {
-              "version": "1.0.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "delayed-stream": "~1.0.0"
-              }
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "concat-stream": {
-              "version": "1.6.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.3.6",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.3",
-                    "isarray": "~1.0.0",
-                    "process-nextick-args": "~2.0.0",
-                    "safe-buffer": "~5.1.1",
-                    "string_decoder": "~1.1.1",
-                    "util-deprecate": "~1.0.1"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                }
-              }
-            },
-            "config-chain": {
-              "version": "1.1.12",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ini": "^1.3.4",
-                "proto-list": "~1.2.1"
-              }
-            },
-            "configstore": {
-              "version": "3.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "dot-prop": "^4.1.0",
-                "graceful-fs": "^4.1.2",
-                "make-dir": "^1.0.0",
-                "unique-string": "^1.0.0",
-                "write-file-atomic": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
-              }
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "copy-concurrently": {
-              "version": "1.0.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "aproba": "^1.1.1",
-                "fs-write-stream-atomic": "^1.0.8",
-                "iferr": "^0.1.5",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.0"
-              },
-              "dependencies": {
-                "aproba": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "iferr": {
-                  "version": "0.1.5",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "create-error-class": {
-              "version": "3.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "capture-stack-trace": "^1.0.0"
-              }
-            },
-            "cross-spawn": {
-              "version": "5.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              },
-              "dependencies": {
-                "lru-cache": {
-                  "version": "4.1.5",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "pseudomap": "^1.0.2",
-                    "yallist": "^2.1.2"
-                  }
-                },
-                "yallist": {
-                  "version": "2.1.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "crypto-random-string": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "cyclist": {
-              "version": "0.2.2",
-              "bundled": true,
-              "dev": true
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "assert-plus": "^1.0.0"
-              }
-            },
-            "debug": {
-              "version": "3.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              },
-              "dependencies": {
-                "ms": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "debuglog": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "decamelize": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "decode-uri-component": {
-              "version": "0.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "deep-extend": {
-              "version": "0.5.1",
-              "bundled": true,
-              "dev": true
-            },
-            "defaults": {
-              "version": "1.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "clone": "^1.0.2"
-              }
-            },
-            "define-properties": {
-              "version": "1.1.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "object-keys": "^1.0.12"
-              }
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "delegates": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "detect-indent": {
-              "version": "5.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "detect-newline": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "dezalgo": {
-              "version": "1.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "asap": "^2.0.0",
-                "wrappy": "1"
-              }
-            },
-            "dot-prop": {
-              "version": "4.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-obj": "^1.0.0"
-              }
-            },
-            "dotenv": {
-              "version": "5.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "duplexer3": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true
-            },
-            "duplexify": {
-              "version": "3.6.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.3.6",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.3",
-                    "isarray": "~1.0.0",
-                    "process-nextick-args": "~2.0.0",
-                    "safe-buffer": "~5.1.1",
-                    "string_decoder": "~1.1.1",
-                    "util-deprecate": "~1.0.1"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                }
-              }
-            },
-            "ecc-jsbn": {
-              "version": "0.1.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-              }
-            },
-            "editor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "encoding": {
-              "version": "0.1.12",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "iconv-lite": "~0.4.13"
-              }
-            },
-            "end-of-stream": {
-              "version": "1.4.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "once": "^1.4.0"
-              }
-            },
-            "env-paths": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "err-code": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "errno": {
-              "version": "0.1.7",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "prr": "~1.0.1"
-              }
-            },
-            "es-abstract": {
-              "version": "1.12.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "es-to-primitive": "^1.1.1",
-                "function-bind": "^1.1.1",
-                "has": "^1.0.1",
-                "is-callable": "^1.1.3",
-                "is-regex": "^1.0.4"
-              }
-            },
-            "es-to-primitive": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-callable": "^1.1.4",
-                "is-date-object": "^1.0.1",
-                "is-symbol": "^1.0.2"
-              }
-            },
-            "es6-promise": {
-              "version": "4.2.8",
-              "bundled": true,
-              "dev": true
-            },
-            "es6-promisify": {
-              "version": "5.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "es6-promise": "^4.0.3"
-              }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "bundled": true,
-              "dev": true
-            },
-            "execa": {
-              "version": "0.7.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "cross-spawn": "^5.0.1",
-                "get-stream": "^3.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
-              },
-              "dependencies": {
-                "get-stream": {
-                  "version": "3.0.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "bundled": true,
-              "dev": true
-            },
-            "fast-deep-equal": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "fast-json-stable-stringify": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "figgy-pudding": {
-              "version": "3.5.1",
-              "bundled": true,
-              "dev": true
-            },
-            "find-npm-prefix": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "find-up": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "locate-path": "^2.0.0"
-              }
-            },
-            "flush-write-stream": {
-              "version": "1.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.4"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.3.6",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.3",
-                    "isarray": "~1.0.0",
-                    "process-nextick-args": "~2.0.0",
-                    "safe-buffer": "~5.1.1",
-                    "string_decoder": "~1.1.1",
-                    "util-deprecate": "~1.0.1"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                }
-              }
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true,
-              "dev": true
-            },
-            "form-data": {
-              "version": "2.3.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "^2.1.12"
-              }
-            },
-            "from2": {
-              "version": "2.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.3.6",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.3",
-                    "isarray": "~1.0.0",
-                    "process-nextick-args": "~2.0.0",
-                    "safe-buffer": "~5.1.1",
-                    "string_decoder": "~1.1.1",
-                    "util-deprecate": "~1.0.1"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                }
-              }
-            },
-            "fs-minipass": {
-              "version": "1.2.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "minipass": "^2.2.1"
-              }
-            },
-            "fs-vacuum": {
-              "version": "1.2.10",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "path-is-inside": "^1.0.1",
-                "rimraf": "^2.5.2"
-              }
-            },
-            "fs-write-stream-atomic": {
-              "version": "1.0.10",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "iferr": "^0.1.5",
-                "imurmurhash": "^0.1.4",
-                "readable-stream": "1 || 2"
-              },
-              "dependencies": {
-                "iferr": {
-                  "version": "0.1.5",
-                  "bundled": true,
-                  "dev": true
-                },
-                "readable-stream": {
-                  "version": "2.3.6",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.3",
-                    "isarray": "~1.0.0",
-                    "process-nextick-args": "~2.0.0",
-                    "safe-buffer": "~5.1.1",
-                    "string_decoder": "~1.1.1",
-                    "util-deprecate": "~1.0.1"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                }
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "function-bind": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-              },
-              "dependencies": {
-                "aproba": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "string-width": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "genfun": {
-              "version": "5.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "gentle-fs": {
-              "version": "2.2.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "aproba": "^1.1.2",
-                "chownr": "^1.1.2",
-                "fs-vacuum": "^1.2.10",
-                "graceful-fs": "^4.1.11",
-                "iferr": "^0.1.5",
-                "infer-owner": "^1.0.4",
-                "mkdirp": "^0.5.1",
-                "path-is-inside": "^1.0.2",
-                "read-cmd-shim": "^1.0.1",
-                "slide": "^1.1.6"
-              },
-              "dependencies": {
-                "aproba": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "iferr": {
-                  "version": "0.1.5",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "get-caller-file": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "get-stream": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "pump": "^3.0.0"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "assert-plus": "^1.0.0"
-              }
-            },
-            "glob": {
-              "version": "7.1.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
-            "global-dirs": {
-              "version": "0.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ini": "^1.3.4"
-              }
-            },
-            "got": {
-              "version": "6.7.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "create-error-class": "^3.0.0",
-                "duplexer3": "^0.1.4",
-                "get-stream": "^3.0.0",
-                "is-redirect": "^1.0.0",
-                "is-retry-allowed": "^1.0.0",
-                "is-stream": "^1.0.0",
-                "lowercase-keys": "^1.0.0",
-                "safe-buffer": "^5.0.1",
-                "timed-out": "^4.0.0",
-                "unzip-response": "^2.0.1",
-                "url-parse-lax": "^1.0.0"
-              },
-              "dependencies": {
-                "get-stream": {
-                  "version": "3.0.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "4.2.2",
-              "bundled": true,
-              "dev": true
-            },
-            "har-schema": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "har-validator": {
-              "version": "5.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ajv": "^5.3.0",
-                "har-schema": "^2.0.0"
-              }
-            },
-            "has": {
-              "version": "1.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "function-bind": "^1.1.1"
-              }
-            },
-            "has-flag": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "has-symbols": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "hosted-git-info": {
-              "version": "2.8.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lru-cache": "^5.1.1"
-              }
-            },
-            "http-cache-semantics": {
-              "version": "3.8.1",
-              "bundled": true,
-              "dev": true
-            },
-            "http-proxy-agent": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "agent-base": "4",
-                "debug": "3.1.0"
-              }
-            },
-            "http-signature": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-              }
-            },
-            "https-proxy-agent": {
-              "version": "2.2.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "agent-base": "^4.3.0",
-                "debug": "^3.1.0"
-              }
-            },
-            "humanize-ms": {
-              "version": "1.2.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ms": "^2.0.0"
-              }
-            },
-            "iconv-lite": {
-              "version": "0.4.23",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
-              }
-            },
-            "iferr": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "ignore-walk": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "minimatch": "^3.0.4"
-              }
-            },
-            "import-lazy": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "imurmurhash": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true
-            },
-            "infer-owner": {
-              "version": "1.0.4",
-              "bundled": true,
-              "dev": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.4",
-              "bundled": true,
-              "dev": true
-            },
-            "ini": {
-              "version": "1.3.5",
-              "bundled": true,
-              "dev": true
-            },
-            "init-package-json": {
-              "version": "1.10.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "glob": "^7.1.1",
-                "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
-                "promzard": "^0.3.0",
-                "read": "~1.0.1",
-                "read-package-json": "1 || 2",
-                "semver": "2.x || 3.x || 4 || 5",
-                "validate-npm-package-license": "^3.0.1",
-                "validate-npm-package-name": "^3.0.0"
-              }
-            },
-            "invert-kv": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "ip": {
-              "version": "1.1.5",
-              "bundled": true,
-              "dev": true
-            },
-            "ip-regex": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-callable": {
-              "version": "1.1.4",
-              "bundled": true,
-              "dev": true
-            },
-            "is-ci": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ci-info": "^1.0.0"
-              },
-              "dependencies": {
-                "ci-info": {
-                  "version": "1.6.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "is-cidr": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "cidr-regex": "^2.0.10"
-              }
-            },
-            "is-date-object": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "is-installed-globally": {
-              "version": "0.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "global-dirs": "^0.1.0",
-                "is-path-inside": "^1.0.0"
-              }
-            },
-            "is-npm": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-obj": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "is-path-inside": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "path-is-inside": "^1.0.1"
-              }
-            },
-            "is-redirect": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-regex": {
-              "version": "1.0.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "has": "^1.0.1"
-              }
-            },
-            "is-retry-allowed": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-symbol": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "has-symbols": "^1.0.0"
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "isexe": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "json-parse-better-errors": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true,
-              "dev": true
-            },
-            "json-schema-traverse": {
-              "version": "0.3.1",
-              "bundled": true,
-              "dev": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "jsonparse": {
-              "version": "1.3.1",
-              "bundled": true,
-              "dev": true
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              }
-            },
-            "latest-version": {
-              "version": "3.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "package-json": "^4.0.0"
-              }
-            },
-            "lazy-property": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lcid": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "invert-kv": "^1.0.0"
-              }
-            },
-            "libcipm": {
-              "version": "4.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "bin-links": "^1.1.2",
-                "bluebird": "^3.5.1",
-                "figgy-pudding": "^3.5.1",
-                "find-npm-prefix": "^1.0.2",
-                "graceful-fs": "^4.1.11",
-                "ini": "^1.3.5",
-                "lock-verify": "^2.0.2",
-                "mkdirp": "^0.5.1",
-                "npm-lifecycle": "^3.0.0",
-                "npm-logical-tree": "^1.2.1",
-                "npm-package-arg": "^6.1.0",
-                "pacote": "^9.1.0",
-                "read-package-json": "^2.0.13",
-                "rimraf": "^2.6.2",
-                "worker-farm": "^1.6.0"
-              }
-            },
-            "libnpm": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "bin-links": "^1.1.2",
-                "bluebird": "^3.5.3",
-                "find-npm-prefix": "^1.0.2",
-                "libnpmaccess": "^3.0.2",
-                "libnpmconfig": "^1.2.1",
-                "libnpmhook": "^5.0.3",
-                "libnpmorg": "^1.0.1",
-                "libnpmpublish": "^1.1.2",
-                "libnpmsearch": "^2.0.2",
-                "libnpmteam": "^1.0.2",
-                "lock-verify": "^2.0.2",
-                "npm-lifecycle": "^3.0.0",
-                "npm-logical-tree": "^1.2.1",
-                "npm-package-arg": "^6.1.0",
-                "npm-profile": "^4.0.2",
-                "npm-registry-fetch": "^4.0.0",
-                "npmlog": "^4.1.2",
-                "pacote": "^9.5.3",
-                "read-package-json": "^2.0.13",
-                "stringify-package": "^1.0.0"
-              }
-            },
-            "libnpmaccess": {
-              "version": "3.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "aproba": "^2.0.0",
-                "get-stream": "^4.0.0",
-                "npm-package-arg": "^6.1.0",
-                "npm-registry-fetch": "^4.0.0"
-              }
-            },
-            "libnpmconfig": {
-              "version": "1.2.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "figgy-pudding": "^3.5.1",
-                "find-up": "^3.0.0",
-                "ini": "^1.3.5"
-              },
-              "dependencies": {
-                "find-up": {
-                  "version": "3.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "locate-path": "^3.0.0"
-                  }
-                },
-                "locate-path": {
-                  "version": "3.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "p-locate": "^3.0.0",
-                    "path-exists": "^3.0.0"
-                  }
-                },
-                "p-limit": {
-                  "version": "2.2.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "p-try": "^2.0.0"
-                  }
-                },
-                "p-locate": {
-                  "version": "3.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "p-limit": "^2.0.0"
-                  }
-                },
-                "p-try": {
-                  "version": "2.2.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "libnpmhook": {
-              "version": "5.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "aproba": "^2.0.0",
-                "figgy-pudding": "^3.4.1",
-                "get-stream": "^4.0.0",
-                "npm-registry-fetch": "^4.0.0"
-              }
-            },
-            "libnpmorg": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "aproba": "^2.0.0",
-                "figgy-pudding": "^3.4.1",
-                "get-stream": "^4.0.0",
-                "npm-registry-fetch": "^4.0.0"
-              }
-            },
-            "libnpmpublish": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "aproba": "^2.0.0",
-                "figgy-pudding": "^3.5.1",
-                "get-stream": "^4.0.0",
-                "lodash.clonedeep": "^4.5.0",
-                "normalize-package-data": "^2.4.0",
-                "npm-package-arg": "^6.1.0",
-                "npm-registry-fetch": "^4.0.0",
-                "semver": "^5.5.1",
-                "ssri": "^6.0.1"
-              }
-            },
-            "libnpmsearch": {
-              "version": "2.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "figgy-pudding": "^3.5.1",
-                "get-stream": "^4.0.0",
-                "npm-registry-fetch": "^4.0.0"
-              }
-            },
-            "libnpmteam": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "aproba": "^2.0.0",
-                "figgy-pudding": "^3.4.1",
-                "get-stream": "^4.0.0",
-                "npm-registry-fetch": "^4.0.0"
-              }
-            },
-            "libnpx": {
-              "version": "10.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "dotenv": "^5.0.1",
-                "npm-package-arg": "^6.0.0",
-                "rimraf": "^2.6.2",
-                "safe-buffer": "^5.1.0",
-                "update-notifier": "^2.3.0",
-                "which": "^1.3.0",
-                "y18n": "^4.0.0",
-                "yargs": "^11.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
-              }
-            },
-            "lock-verify": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "npm-package-arg": "^6.1.0",
-                "semver": "^5.4.1"
-              }
-            },
-            "lockfile": {
-              "version": "1.0.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "signal-exit": "^3.0.2"
-              }
-            },
-            "lodash._baseindexof": {
-              "version": "3.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash._baseuniq": {
-              "version": "4.6.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lodash._createset": "~4.0.0",
-                "lodash._root": "~3.0.0"
-              }
-            },
-            "lodash._bindcallback": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash._cacheindexof": {
-              "version": "3.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash._createcache": {
-              "version": "3.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lodash._getnative": "^3.0.0"
-              }
-            },
-            "lodash._createset": {
-              "version": "4.0.3",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash._getnative": {
-              "version": "3.9.1",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash._root": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.clonedeep": {
-              "version": "4.5.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.restparam": {
-              "version": "3.6.1",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.union": {
-              "version": "4.6.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.uniq": {
-              "version": "4.5.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lodash.without": {
-              "version": "4.4.0",
-              "bundled": true,
-              "dev": true
-            },
-            "lowercase-keys": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "lru-cache": {
-              "version": "5.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "yallist": "^3.0.2"
-              }
-            },
-            "make-dir": {
-              "version": "1.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "pify": "^3.0.0"
-              }
-            },
-            "make-fetch-happen": {
-              "version": "5.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "agentkeepalive": "^3.4.1",
-                "cacache": "^12.0.0",
-                "http-cache-semantics": "^3.8.1",
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.1",
-                "lru-cache": "^5.1.1",
-                "mississippi": "^3.0.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^4.0.0",
-                "ssri": "^6.0.0"
-              }
-            },
-            "meant": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "mem": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "mimic-fn": "^1.0.0"
-              }
-            },
-            "mime-db": {
-              "version": "1.35.0",
-              "bundled": true,
-              "dev": true
-            },
-            "mime-types": {
-              "version": "2.1.19",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "mime-db": "~1.35.0"
-              }
-            },
-            "mimic-fn": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true,
-              "dev": true
-            },
-            "minipass": {
-              "version": "2.3.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              },
-              "dependencies": {
-                "yallist": {
-                  "version": "3.0.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "minizlib": {
-              "version": "1.2.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "minipass": "^2.2.1"
-              }
-            },
-            "mississippi": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "concat-stream": "^1.5.0",
-                "duplexify": "^3.4.2",
-                "end-of-stream": "^1.1.0",
-                "flush-write-stream": "^1.0.0",
-                "from2": "^2.1.0",
-                "parallel-transform": "^1.1.0",
-                "pump": "^3.0.0",
-                "pumpify": "^1.3.3",
-                "stream-each": "^1.1.0",
-                "through2": "^2.0.0"
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "move-concurrently": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "aproba": "^1.1.1",
-                "copy-concurrently": "^1.0.0",
-                "fs-write-stream-atomic": "^1.0.8",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.3"
-              },
-              "dependencies": {
-                "aproba": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "ms": {
-              "version": "2.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "mute-stream": {
-              "version": "0.0.7",
-              "bundled": true,
-              "dev": true
-            },
-            "node-fetch-npm": {
-              "version": "2.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "encoding": "^0.1.11",
-                "json-parse-better-errors": "^1.0.0",
-                "safe-buffer": "^5.1.1"
-              }
-            },
-            "node-gyp": {
-              "version": "5.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "env-paths": "^1.0.0",
-                "glob": "^7.0.3",
-                "graceful-fs": "^4.1.2",
-                "mkdirp": "^0.5.0",
-                "nopt": "2 || 3",
-                "npmlog": "0 || 1 || 2 || 3 || 4",
-                "request": "^2.87.0",
-                "rimraf": "2",
-                "semver": "~5.3.0",
-                "tar": "^4.4.8",
-                "which": "1"
-              },
-              "dependencies": {
-                "nopt": {
-                  "version": "3.0.6",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "abbrev": "1"
-                  }
-                },
-                "semver": {
-                  "version": "5.3.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "nopt": {
-              "version": "4.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
-              }
-            },
-            "normalize-package-data": {
-              "version": "2.5.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "hosted-git-info": "^2.1.4",
-                "resolve": "^1.10.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
-              },
-              "dependencies": {
-                "resolve": {
-                  "version": "1.10.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "path-parse": "^1.0.6"
-                  }
-                }
-              }
-            },
-            "npm-audit-report": {
-              "version": "1.3.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "cli-table3": "^0.5.0",
-                "console-control-strings": "^1.1.0"
-              }
-            },
-            "npm-bundled": {
-              "version": "1.0.6",
-              "bundled": true,
-              "dev": true
-            },
-            "npm-cache-filename": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "npm-install-checks": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "semver": "^2.3.0 || 3.x || 4 || 5"
-              }
-            },
-            "npm-lifecycle": {
-              "version": "3.1.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "byline": "^5.0.0",
-                "graceful-fs": "^4.1.15",
-                "node-gyp": "^5.0.2",
-                "resolve-from": "^4.0.0",
-                "slide": "^1.1.6",
-                "uid-number": "0.0.6",
-                "umask": "^1.1.0",
-                "which": "^1.3.1"
-              }
-            },
-            "npm-logical-tree": {
-              "version": "1.2.1",
-              "bundled": true,
-              "dev": true
-            },
-            "npm-package-arg": {
-              "version": "6.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "hosted-git-info": "^2.7.1",
-                "osenv": "^0.1.5",
-                "semver": "^5.6.0",
-                "validate-npm-package-name": "^3.0.0"
-              }
-            },
-            "npm-packlist": {
-              "version": "1.4.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ignore-walk": "^3.0.1",
-                "npm-bundled": "^1.0.1"
-              }
-            },
-            "npm-pick-manifest": {
-              "version": "3.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "figgy-pudding": "^3.5.1",
-                "npm-package-arg": "^6.0.0",
-                "semver": "^5.4.1"
-              }
-            },
-            "npm-profile": {
-              "version": "4.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "aproba": "^1.1.2 || 2",
-                "figgy-pudding": "^3.4.1",
-                "npm-registry-fetch": "^4.0.0"
-              }
-            },
-            "npm-registry-fetch": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "JSONStream": "^1.3.4",
-                "bluebird": "^3.5.1",
-                "figgy-pudding": "^3.4.1",
-                "lru-cache": "^5.1.1",
-                "make-fetch-happen": "^5.0.0",
-                "npm-package-arg": "^6.1.0"
-              }
-            },
-            "npm-run-path": {
-              "version": "2.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "path-key": "^2.0.0"
-              }
-            },
-            "npm-user-validate": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-              }
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "oauth-sign": {
-              "version": "0.9.0",
-              "bundled": true,
-              "dev": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "object-keys": {
-              "version": "1.0.12",
-              "bundled": true,
-              "dev": true
-            },
-            "object.getownpropertydescriptors": {
-              "version": "2.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "define-properties": "^1.1.2",
-                "es-abstract": "^1.5.1"
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "wrappy": "1"
-              }
-            },
-            "opener": {
-              "version": "1.5.1",
-              "bundled": true,
-              "dev": true
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "os-locale": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "execa": "^0.7.0",
-                "lcid": "^1.0.0",
-                "mem": "^1.1.0"
-              }
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "osenv": {
-              "version": "0.1.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
-              }
-            },
-            "p-finally": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "p-limit": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-try": "^1.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-limit": "^1.1.0"
-              }
-            },
-            "p-try": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "package-json": {
-              "version": "4.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "got": "^6.7.1",
-                "registry-auth-token": "^3.0.1",
-                "registry-url": "^3.0.3",
-                "semver": "^5.1.0"
-              }
-            },
-            "pacote": {
-              "version": "9.5.8",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "bluebird": "^3.5.3",
-                "cacache": "^12.0.2",
-                "chownr": "^1.1.2",
-                "figgy-pudding": "^3.5.1",
-                "get-stream": "^4.1.0",
-                "glob": "^7.1.3",
-                "infer-owner": "^1.0.4",
-                "lru-cache": "^5.1.1",
-                "make-fetch-happen": "^5.0.0",
-                "minimatch": "^3.0.4",
-                "minipass": "^2.3.5",
-                "mississippi": "^3.0.0",
-                "mkdirp": "^0.5.1",
-                "normalize-package-data": "^2.4.0",
-                "npm-package-arg": "^6.1.0",
-                "npm-packlist": "^1.1.12",
-                "npm-pick-manifest": "^3.0.0",
-                "npm-registry-fetch": "^4.0.0",
-                "osenv": "^0.1.5",
-                "promise-inflight": "^1.0.1",
-                "promise-retry": "^1.1.1",
-                "protoduck": "^5.0.1",
-                "rimraf": "^2.6.2",
-                "safe-buffer": "^5.1.2",
-                "semver": "^5.6.0",
-                "ssri": "^6.0.1",
-                "tar": "^4.4.10",
-                "unique-filename": "^1.1.1",
-                "which": "^1.3.1"
-              },
-              "dependencies": {
-                "minipass": {
-                  "version": "2.3.5",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "^5.1.2",
-                    "yallist": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "parallel-transform": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "cyclist": "~0.2.2",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.1.5"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.3.6",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.3",
-                    "isarray": "~1.0.0",
-                    "process-nextick-args": "~2.0.0",
-                    "safe-buffer": "~5.1.1",
-                    "string_decoder": "~1.1.1",
-                    "util-deprecate": "~1.0.1"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                }
-              }
-            },
-            "path-exists": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "path-is-inside": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "path-key": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "path-parse": {
-              "version": "1.0.6",
-              "bundled": true,
-              "dev": true
-            },
-            "performance-now": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "pify": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "prepend-http": {
-              "version": "1.0.4",
-              "bundled": true,
-              "dev": true
-            },
-            "process-nextick-args": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "promise-inflight": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "promise-retry": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "err-code": "^1.0.0",
-                "retry": "^0.10.0"
-              },
-              "dependencies": {
-                "retry": {
-                  "version": "0.10.1",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "promzard": {
-              "version": "0.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "read": "1"
-              }
-            },
-            "proto-list": {
-              "version": "1.2.4",
-              "bundled": true,
-              "dev": true
-            },
-            "protoduck": {
-              "version": "5.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "genfun": "^5.0.0"
-              }
-            },
-            "prr": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "pseudomap": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "psl": {
-              "version": "1.1.29",
-              "bundled": true,
-              "dev": true
-            },
-            "pump": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-              }
-            },
-            "pumpify": {
-              "version": "1.5.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "duplexify": "^3.6.0",
-                "inherits": "^2.0.3",
-                "pump": "^2.0.0"
-              },
-              "dependencies": {
-                "pump": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "end-of-stream": "^1.1.0",
-                    "once": "^1.3.1"
-                  }
-                }
-              }
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true,
-              "dev": true
-            },
-            "qrcode-terminal": {
-              "version": "0.12.0",
-              "bundled": true,
-              "dev": true
-            },
-            "qs": {
-              "version": "6.5.2",
-              "bundled": true,
-              "dev": true
-            },
-            "query-string": {
-              "version": "6.8.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "decode-uri-component": "^0.2.0",
-                "split-on-first": "^1.0.0",
-                "strict-uri-encode": "^2.0.0"
-              }
-            },
-            "qw": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "rc": {
-              "version": "1.2.7",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "deep-extend": "^0.5.1",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "read": {
-              "version": "1.0.7",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "mute-stream": "~0.0.4"
-              }
-            },
-            "read-cmd-shim": {
-              "version": "1.0.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.2"
-              }
-            },
-            "read-installed": {
-              "version": "4.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "debuglog": "^1.0.1",
-                "graceful-fs": "^4.1.2",
-                "read-package-json": "^2.0.0",
-                "readdir-scoped-modules": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "slide": "~1.1.3",
-                "util-extend": "^1.0.1"
-              }
-            },
-            "read-package-json": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "glob": "^7.1.1",
-                "graceful-fs": "^4.1.2",
-                "json-parse-better-errors": "^1.0.1",
-                "normalize-package-data": "^2.0.0",
-                "slash": "^1.0.0"
-              }
-            },
-            "read-package-tree": {
-              "version": "5.3.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "read-package-json": "^2.0.0",
-                "readdir-scoped-modules": "^1.0.0",
-                "util-promisify": "^2.1.0"
-              }
-            },
-            "readable-stream": {
-              "version": "3.4.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-              }
-            },
-            "readdir-scoped-modules": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "debuglog": "^1.0.1",
-                "dezalgo": "^1.0.0",
-                "graceful-fs": "^4.1.2",
-                "once": "^1.3.0"
-              }
-            },
-            "registry-auth-token": {
-              "version": "3.3.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "rc": "^1.1.6",
-                "safe-buffer": "^5.0.1"
-              }
-            },
-            "registry-url": {
-              "version": "3.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "rc": "^1.0.1"
-              }
-            },
-            "request": {
-              "version": "2.88.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
-              }
-            },
-            "require-directory": {
-              "version": "2.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "require-main-filename": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "resolve-from": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "retry": {
-              "version": "0.12.0",
-              "bundled": true,
-              "dev": true
-            },
-            "rimraf": {
-              "version": "2.6.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            },
-            "run-queue": {
-              "version": "1.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "aproba": "^1.1.1"
-              },
-              "dependencies": {
-                "aproba": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "safer-buffer": {
-              "version": "2.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "semver": {
-              "version": "5.7.1",
-              "bundled": true,
-              "dev": true
-            },
-            "semver-diff": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "semver": "^5.0.3"
-              }
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "sha": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.2"
-              }
-            },
-            "shebang-command": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "shebang-regex": "^1.0.0"
-              }
-            },
-            "shebang-regex": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "slash": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "slide": {
-              "version": "1.1.6",
-              "bundled": true,
-              "dev": true
-            },
-            "smart-buffer": {
-              "version": "4.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "socks": {
-              "version": "2.3.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ip": "^1.1.5",
-                "smart-buffer": "4.0.2"
-              }
-            },
-            "socks-proxy-agent": {
-              "version": "4.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "agent-base": "~4.2.1",
-                "socks": "~2.3.2"
-              },
-              "dependencies": {
-                "agent-base": {
-                  "version": "4.2.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "es6-promisify": "^5.0.0"
-                  }
-                }
-              }
-            },
-            "sorted-object": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "sorted-union-stream": {
-              "version": "2.1.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "from2": "^1.3.0",
-                "stream-iterate": "^1.1.0"
-              },
-              "dependencies": {
-                "from2": {
-                  "version": "1.3.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "inherits": "~2.0.1",
-                    "readable-stream": "~1.1.10"
-                  }
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "bundled": true,
-                  "dev": true
-                },
-                "readable-stream": {
-                  "version": "1.1.14",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.1",
-                    "isarray": "0.0.1",
-                    "string_decoder": "~0.10.x"
-                  }
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "spdx-correct": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
-              }
-            },
-            "spdx-exceptions": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "spdx-expression-parse": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-              }
-            },
-            "spdx-license-ids": {
-              "version": "3.0.3",
-              "bundled": true,
-              "dev": true
-            },
-            "split-on-first": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "sshpk": {
-              "version": "1.14.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
-              }
-            },
-            "ssri": {
-              "version": "6.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "figgy-pudding": "^3.5.1"
-              }
-            },
-            "stream-each": {
-              "version": "1.2.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "end-of-stream": "^1.1.0",
-                "stream-shift": "^1.0.0"
-              }
-            },
-            "stream-iterate": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "readable-stream": "^2.1.5",
-                "stream-shift": "^1.0.0"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.3.6",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.3",
-                    "isarray": "~1.0.0",
-                    "process-nextick-args": "~2.0.0",
-                    "safe-buffer": "~5.1.1",
-                    "string_decoder": "~1.1.1",
-                    "util-deprecate": "~1.0.1"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                }
-              }
-            },
-            "stream-shift": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "strict-uri-encode": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "string-width": {
-              "version": "2.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "3.0.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "is-fullwidth-code-point": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "strip-ansi": {
-                  "version": "4.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "ansi-regex": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "string_decoder": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            },
-            "stringify-package": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            },
-            "strip-eof": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "supports-color": {
-              "version": "5.4.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            },
-            "tar": {
-              "version": "4.4.10",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "chownr": "^1.1.1",
-                "fs-minipass": "^1.2.5",
-                "minipass": "^2.3.5",
-                "minizlib": "^1.2.1",
-                "mkdirp": "^0.5.0",
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.3"
-              },
-              "dependencies": {
-                "minipass": {
-                  "version": "2.3.5",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "^5.1.2",
-                    "yallist": "^3.0.0"
-                  }
-                },
-                "yallist": {
-                  "version": "3.0.3",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "term-size": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "execa": "^0.7.0"
-              }
-            },
-            "text-table": {
-              "version": "0.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true,
-              "dev": true
-            },
-            "through2": {
-              "version": "2.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "readable-stream": "^2.1.5",
-                "xtend": "~4.0.1"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.3.6",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.3",
-                    "isarray": "~1.0.0",
-                    "process-nextick-args": "~2.0.0",
-                    "safe-buffer": "~5.1.1",
-                    "string_decoder": "~1.1.1",
-                    "util-deprecate": "~1.0.1"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                }
-              }
-            },
-            "timed-out": {
-              "version": "4.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "tiny-relative-date": {
-              "version": "1.3.0",
-              "bundled": true,
-              "dev": true
-            },
-            "tough-cookie": {
-              "version": "2.4.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "psl": "^1.1.24",
-                "punycode": "^1.4.1"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "^5.0.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "typedarray": {
-              "version": "0.0.6",
-              "bundled": true,
-              "dev": true
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "bundled": true,
-              "dev": true
-            },
-            "umask": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "unique-filename": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "unique-slug": "^2.0.0"
-              }
-            },
-            "unique-slug": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "imurmurhash": "^0.1.4"
-              }
-            },
-            "unique-string": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "crypto-random-string": "^1.0.0"
-              }
-            },
-            "unpipe": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "unzip-response": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "update-notifier": {
-              "version": "2.5.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "boxen": "^1.2.1",
-                "chalk": "^2.0.1",
-                "configstore": "^3.0.0",
-                "import-lazy": "^2.1.0",
-                "is-ci": "^1.0.10",
-                "is-installed-globally": "^0.1.0",
-                "is-npm": "^1.0.0",
-                "latest-version": "^3.0.0",
-                "semver-diff": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
-              }
-            },
-            "url-parse-lax": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "prepend-http": "^1.0.1"
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "util-extend": {
-              "version": "1.0.3",
-              "bundled": true,
-              "dev": true
-            },
-            "util-promisify": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "object.getownpropertydescriptors": "^2.0.3"
-              }
-            },
-            "uuid": {
-              "version": "3.3.2",
-              "bundled": true,
-              "dev": true
-            },
-            "validate-npm-package-license": {
-              "version": "3.0.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
-              }
-            },
-            "validate-npm-package-name": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "builtins": "^1.0.3"
-              }
-            },
-            "verror": {
-              "version": "1.10.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
-              }
-            },
-            "wcwidth": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "defaults": "^1.0.3"
-              }
-            },
-            "which": {
-              "version": "1.3.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "isexe": "^2.0.0"
-              }
-            },
-            "which-module": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "wide-align": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "string-width": "^1.0.2"
-              },
-              "dependencies": {
-                "string-width": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "widest-line": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "string-width": "^2.1.1"
-              }
-            },
-            "worker-farm": {
-              "version": "1.7.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "errno": "~0.1.7"
-              }
-            },
-            "wrap-ansi": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
-              },
-              "dependencies": {
-                "string-width": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "write-file-atomic": {
-              "version": "2.4.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.11",
-                "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.2"
-              }
-            },
-            "xdg-basedir": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "y18n": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "yallist": {
-              "version": "3.0.3",
-              "bundled": true,
-              "dev": true
-            },
-            "yargs": {
-              "version": "11.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "cliui": "^4.0.0",
-                "decamelize": "^1.1.1",
-                "find-up": "^2.1.0",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^2.0.0",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^9.0.2"
-              },
-              "dependencies": {
-                "y18n": {
-                  "version": "3.2.1",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "yargs-parser": {
-              "version": "9.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "camelcase": "^4.1.0"
-              }
-            }
-          }
-        },
         "npm-run-path": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
-          "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.0.tgz",
+          "integrity": "sha512-8eyAOAH+bYXFPSnNnKr3J+yoybe8O87Is5rtAQ8qRczJz1ajcsjg8l2oZqP+Ppx15Ii3S1vUTjQN2h4YO2tWWQ==",
           "dev": true,
           "requires": {
             "path-key": "^3.0.0"
@@ -4343,13 +833,37 @@
             "parse-json": "^5.0.0",
             "type-fest": "^0.6.0"
           }
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
+          "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
     },
     "@semantic-release/release-notes-generator": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-7.1.4.tgz",
-      "integrity": "sha512-pWPouZujddgb6t61t9iA9G3yIfp3TeQ7bPbV1ixYSeP6L7gI1+Du82fY/OHfEwyifpymLUQW0XnIKgKct5IMMw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-7.3.0.tgz",
+      "integrity": "sha512-6ozBLHM9XZR6Z8PFSKssLtwBYc5l1WOnxj034F8051QOo3TMKDDPKwdj2Niyc+e7ru7tGa3Ftq7nfN0YnD6//A==",
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "^5.0.0",
@@ -4357,16 +871,17 @@
         "conventional-commits-filter": "^2.0.0",
         "conventional-commits-parser": "^3.0.0",
         "debug": "^4.0.0",
-        "get-stream": "^4.0.0",
-        "import-from": "^2.1.0",
-        "into-stream": "^4.0.0",
-        "lodash": "^4.17.4"
+        "get-stream": "^5.0.0",
+        "import-from": "^3.0.0",
+        "into-stream": "^5.0.0",
+        "lodash": "^4.17.4",
+        "read-pkg-up": "^6.0.0"
       },
       "dependencies": {
         "conventional-changelog-angular": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.2.tgz",
-          "integrity": "sha512-yx7m7lVrXmt4nKWQgWZqxSALEiAKZhOAcbxdUaU9575mB0CzXVbgrgpfSnSP7OqWDUTYGD0YVJ0MSRdyOPgAwA==",
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.5.tgz",
+          "integrity": "sha512-RrkdWnL/TVyWV1ayWmSsrWorsTDqjL/VwG5ZSEneBQrd65ONcfeA1cW7FLtNweQyMiKOyriCMTKRSlk18DjTrw==",
           "dev": true,
           "requires": {
             "compare-func": "^1.3.1",
@@ -4374,27 +889,45 @@
           }
         },
         "conventional-commits-parser": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.1.tgz",
-          "integrity": "sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==",
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.5.tgz",
+          "integrity": "sha512-qVz9+5JwdJzsbt7JbJ6P7NOXBGt8CyLFJYSjKAuPSgO+5UGfcsbk9EMR+lI8Unlvx6qwIc2YDJlrGIfay2ehNA==",
           "dev": true,
           "requires": {
             "JSONStream": "^1.0.4",
-            "is-text-path": "^1.0.0",
+            "is-text-path": "^2.0.0",
             "lodash": "^4.2.1",
             "meow": "^4.0.0",
             "split2": "^2.0.0",
-            "through2": "^2.0.0",
+            "through2": "^3.0.0",
             "trim-off-newlines": "^1.0.0"
           }
         },
         "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
+          }
+        },
+        "is-text-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
+          "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
+          "dev": true,
+          "requires": {
+            "text-extensions": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
           }
         },
         "meow": {
@@ -4412,7 +945,137 @@
             "read-pkg-up": "^3.0.0",
             "redent": "^2.0.0",
             "trim-newlines": "^2.0.0"
+          },
+          "dependencies": {
+            "read-pkg-up": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+              "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+              "dev": true,
+              "requires": {
+                "find-up": "^2.0.0",
+                "read-pkg": "^3.0.0"
+              }
+            }
           }
+        },
+        "p-limit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "read-pkg-up": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-6.0.0.tgz",
+          "integrity": "sha512-odtTvLl+EXo1eTsMnoUHRmg/XmXdTkwXVxy4VFE9Kp6cCq7b3l7QMdBndND3eAFzrbSAXC/WCUOQQ9rLjifKZw==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0",
+            "read-pkg": "^5.1.1",
+            "type-fest": "^0.5.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+              "dev": true,
+              "requires": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+              }
+            },
+            "normalize-package-data": {
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+              "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+              "dev": true,
+              "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+              }
+            },
+            "read-pkg": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+              "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+              "dev": true,
+              "requires": {
+                "@types/normalize-package-data": "^2.4.0",
+                "normalize-package-data": "^2.5.0",
+                "parse-json": "^5.0.0",
+                "type-fest": "^0.6.0"
+              },
+              "dependencies": {
+                "type-fest": {
+                  "version": "0.6.0",
+                  "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+                  "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "text-extensions": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.0.0.tgz",
+          "integrity": "sha512-F91ZqLgvi1E0PdvmxMgp+gcf6q8fMH7mhdwWfzXnl1k+GbpQDmi8l7DzLC5JTASKbwpY3TfxajAUzAXcv2NmsQ==",
+          "dev": true
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        },
+        "type-fest": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+          "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+          "dev": true
         }
       }
     },
@@ -4495,13 +1158,21 @@
       }
     },
     "aggregate-error": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-2.0.0.tgz",
-      "integrity": "sha512-xA1VQPApQdDehIIpS3gBFkMGDRb9pDYwZPVUOoX8A0lU3GB0mjiACqsa9ByBurU53erhjamf5I4VNRitCfXhjg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
       "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
-        "indent-string": "^3.0.0"
+        "indent-string": "^4.0.0"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
+        }
       }
     },
     "ajv": {
@@ -4584,6 +1255,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
+    "array-uniq": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.1.0.tgz",
+      "integrity": "sha512-bdHxtev7FN6+MXI1YFW0Q8mQ8dTJc2S8AMfju+ZR77pbg2yAdVyDlwkaUI7Har0LyOMRFPHrJ9lYdyjZZswdlQ==",
       "dev": true
     },
     "arrify": {
@@ -4777,9 +1454,9 @@
       "dev": true
     },
     "clean-stack": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.0.0.tgz",
-      "integrity": "sha512-VEoL9Qh7I8s8iHnV53DaeWSt8NJ0g3khMfK6NiCPB7H657juhro+cSw2O88uo3bo0c0X5usamtXk0/Of0wXa5A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
     },
     "cli-cursor": {
@@ -4852,9 +1529,9 @@
       "dev": true
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "optional": true
     },
@@ -4905,21 +1582,21 @@
       }
     },
     "conventional-changelog-writer": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.2.tgz",
-      "integrity": "sha512-d8/FQY/fix2xXEBUhOo8u3DCbyEw3UOQgYHxLsPDw+wHUDma/GQGAGsGtoH876WyNs32fViHmTOUrgRKVLvBug==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.9.tgz",
+      "integrity": "sha512-2Y3QfiAM37WvDMjkVNaRtZgxVzWKj73HE61YQ/95T53yle+CRwTVSl6Gbv/lWVKXeZcM5af9n9TDVf0k7Xh+cw==",
       "dev": true,
       "requires": {
         "compare-func": "^1.3.1",
-        "conventional-commits-filter": "^2.0.1",
+        "conventional-commits-filter": "^2.0.2",
         "dateformat": "^3.0.0",
-        "handlebars": "^4.0.2",
+        "handlebars": "^4.4.0",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.2.1",
         "meow": "^4.0.0",
-        "semver": "^5.5.0",
+        "semver": "^6.0.0",
         "split": "^1.0.0",
-        "through2": "^2.0.0"
+        "through2": "^3.0.0"
       },
       "dependencies": {
         "meow": {
@@ -4938,16 +1615,31 @@
             "redent": "^2.0.0",
             "trim-newlines": "^2.0.0"
           }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
         }
       }
     },
     "conventional-commits-filter": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.1.tgz",
-      "integrity": "sha512-92OU8pz/977udhBjgPEbg3sbYzIxMDFTlQT97w7KdhR9igNqdJvy8smmedAAgn4tPiqseFloKkrVfbXCVd+E7A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.2.tgz",
+      "integrity": "sha512-WpGKsMeXfs21m1zIw4s9H5sys2+9JccTzpN6toXtxhpw2VNF2JUXwIakthKBy+LN4DvJm+TzWhxOMWOs1OFCFQ==",
       "dev": true,
       "requires": {
-        "is-subset": "^0.1.1",
+        "lodash.ismatch": "^4.4.0",
         "modify-values": "^1.0.0"
       }
     },
@@ -5033,6 +1725,12 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
+    },
+    "crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -5178,9 +1876,9 @@
       }
     },
     "env-ci": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-4.1.1.tgz",
-      "integrity": "sha512-eTgpkALDeYRGNhYM2fO9LKsWDifoUgKL7hxpPZqFMP2IU7f+r89DtKqCmk3yQB/jxS8CmZTfKnWO5TiIDFs9Hw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-4.5.0.tgz",
+      "integrity": "sha512-0b5ihp/O/tsxWvzEY/Ags+3SL+F9eFci9ZF2Mqx/NHYCaV3cfpoPZW8qx1fcQAHOjWD9wSWsByewzimvGar/4Q==",
       "dev": true,
       "requires": {
         "execa": "^1.0.0",
@@ -5200,15 +1898,6 @@
             "p-finally": "^1.0.0",
             "signal-exit": "^3.0.0",
             "strip-eof": "^1.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
           }
         }
       }
@@ -5656,28 +2345,16 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.0.4.tgz",
-      "integrity": "sha512-wkIbV6qg37xTJwqSsdnIphL1e+LaGz4AIQqr00mIubMaEhv1/HEmJ0uuCGZRNRUkZZmOB5mJKO0ZUTVq+SxMQg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
+      "integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
       "dev": true,
       "requires": {
-        "@nodelib/fs.stat": "^2.0.1",
-        "@nodelib/fs.walk": "^1.2.1",
-        "glob-parent": "^5.0.0",
-        "is-glob": "^4.0.1",
-        "merge2": "^1.2.3",
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
         "micromatch": "^4.0.2"
-      },
-      "dependencies": {
-        "is-glob": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        }
       }
     },
     "fast-json-stable-stringify": {
@@ -5745,14 +2422,6 @@
       "requires": {
         "array-uniq": "^2.1.0",
         "semver-regex": "^2.0.0"
-      },
-      "dependencies": {
-        "array-uniq": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.1.0.tgz",
-          "integrity": "sha512-bdHxtev7FN6+MXI1YFW0Q8mQ8dTJc2S8AMfju+ZR77pbg2yAdVyDlwkaUI7Har0LyOMRFPHrJ9lYdyjZZswdlQ==",
-          "dev": true
-        }
       }
     },
     "flat-cache": {
@@ -5783,14 +2452,22 @@
       }
     },
     "fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
+        "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+          "dev": true
+        }
       }
     },
     "fs.realpath": {
@@ -5904,9 +2581,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-      "integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -5969,9 +2646,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-      "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
+      "integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -6041,9 +2718,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
+      "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
       "dev": true,
       "requires": {
         "agent-base": "^4.3.0",
@@ -6060,6 +2737,12 @@
           }
         }
       }
+    },
+    "human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true
     },
     "husky": {
       "version": "3.0.5",
@@ -6280,18 +2963,18 @@
       }
     },
     "import-from": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
-      "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+      "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
       "dev": true,
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "^5.0.0"
       },
       "dependencies": {
         "resolve-from": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
           "dev": true
         }
       }
@@ -6371,13 +3054,13 @@
       }
     },
     "into-stream": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-4.0.0.tgz",
-      "integrity": "sha512-i29KNyE5r0Y/UQzcQ0IbZO1MYJ53Jn0EcFRZPj5FzWKYH17kDFEOwuA+3jroymOI06SW1dEDnly9A1CAreC5dg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-5.1.1.tgz",
+      "integrity": "sha512-krrAJ7McQxGGmvaYbB7Q1mcA+cRwg9Ij2RfWIeVesNBgVDZmzY/Fa4IpZUT3bmdRzMzdf/mzltCG2Dq99IZGBA==",
       "dev": true,
       "requires": {
-        "from2": "^2.1.1",
-        "p-is-promise": "^2.0.0"
+        "from2": "^2.3.0",
+        "p-is-promise": "^3.0.0"
       }
     },
     "is-arrayish": {
@@ -6491,12 +3174,6 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
-    "is-subset": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
-      "dev": true
-    },
     "is-symbol": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
@@ -6539,9 +3216,9 @@
       "dev": true
     },
     "issue-parser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-4.0.0.tgz",
-      "integrity": "sha512-1RmmAXHl5+cqTZ9dRr861xWy0Gkc9TWTEklgjKv+nhlB1dY1NmGBV8b20jTWRL5cPGpOIXkz84kEcDBM8Nc0cw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-5.0.0.tgz",
+      "integrity": "sha512-q/16W7EPHRL0FKVz9NU++TUsoygXGj6JOi88oulyAcQG+IEZ0T6teVdE+VLbe19OfL/tbV8Wi3Dfo0HedeHW0Q==",
       "dev": true,
       "requires": {
         "lodash.capitalize": "^4.2.1",
@@ -6684,6 +3361,12 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.ismatch": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+      "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
       "dev": true
     },
     "lodash.isplainobject": {
@@ -6972,33 +3655,33 @@
       }
     },
     "normalize-url": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
-      "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
       "dev": true
     },
     "npm": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.5.0.tgz",
-      "integrity": "sha512-SPq8zG2Kto+Xrq55E97O14Jla13PmQT5kSnvwBj88BmJZ5Nvw++OmlWfhjkB67pcgP5UEXljEtnGFKZtOgt6MQ==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.12.0.tgz",
+      "integrity": "sha512-juj5VkB3/k+PWbJUnXD7A/8oc8zLusDnK/sV9PybSalsbOVOTIp5vSE0rz5rQ7BsmUgQS47f/L2GYQnWXaKgnQ==",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.3.4",
+        "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
         "ansicolors": "~0.3.2",
         "ansistyles": "~0.1.3",
-        "aproba": "~1.2.0",
+        "aproba": "^2.0.0",
         "archy": "~1.0.0",
-        "bin-links": "^1.1.2",
-        "bluebird": "^3.5.3",
-        "byte-size": "^4.0.3",
-        "cacache": "^11.2.0",
-        "call-limit": "~1.1.0",
-        "chownr": "~1.0.1",
-        "ci-info": "^1.6.0",
+        "bin-links": "^1.1.3",
+        "bluebird": "^3.5.5",
+        "byte-size": "^5.0.1",
+        "cacache": "^12.0.3",
+        "call-limit": "^1.1.1",
+        "chownr": "^1.1.2",
+        "ci-info": "^2.0.0",
         "cli-columns": "^3.1.2",
-        "cli-table3": "^0.5.0",
-        "cmd-shim": "~2.0.2",
+        "cli-table3": "^0.5.1",
+        "cmd-shim": "^3.0.3",
         "columnify": "~1.5.4",
         "config-chain": "^1.1.12",
         "debuglog": "*",
@@ -7010,24 +3693,30 @@
         "find-npm-prefix": "^1.0.2",
         "fs-vacuum": "~1.2.10",
         "fs-write-stream-atomic": "~1.0.10",
-        "gentle-fs": "^2.0.1",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.1.15",
+        "gentle-fs": "^2.2.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.2",
         "has-unicode": "~2.0.1",
-        "hosted-git-info": "^2.7.1",
+        "hosted-git-info": "^2.8.5",
         "iferr": "^1.0.2",
         "imurmurhash": "*",
+        "infer-owner": "^1.0.4",
         "inflight": "~1.0.6",
-        "inherits": "~2.0.3",
+        "inherits": "^2.0.4",
         "ini": "^1.3.5",
         "init-package-json": "^1.10.3",
-        "is-cidr": "^2.0.6",
+        "is-cidr": "^3.0.0",
         "json-parse-better-errors": "^1.0.2",
         "lazy-property": "~1.0.0",
-        "libcipm": "^2.0.2",
-        "libnpmhook": "^4.0.1",
+        "libcipm": "^4.0.4",
+        "libnpm": "^3.0.1",
+        "libnpmaccess": "^3.0.2",
+        "libnpmhook": "^5.0.3",
+        "libnpmorg": "^1.0.1",
+        "libnpmsearch": "^2.0.2",
+        "libnpmteam": "^1.0.2",
         "libnpx": "^10.2.0",
-        "lock-verify": "^2.0.2",
+        "lock-verify": "^2.1.0",
         "lockfile": "^1.0.4",
         "lodash._baseindexof": "*",
         "lodash._baseuniq": "~4.6.0",
@@ -7040,73 +3729,71 @@
         "lodash.union": "~4.6.0",
         "lodash.uniq": "~4.5.0",
         "lodash.without": "~4.4.0",
-        "lru-cache": "^4.1.3",
+        "lru-cache": "^5.1.1",
         "meant": "~1.0.1",
         "mississippi": "^3.0.0",
         "mkdirp": "~0.5.1",
         "move-concurrently": "^1.0.1",
-        "node-gyp": "^3.8.0",
+        "node-gyp": "^5.0.5",
         "nopt": "~4.0.1",
-        "normalize-package-data": "~2.4.0",
-        "npm-audit-report": "^1.3.1",
+        "normalize-package-data": "^2.5.0",
+        "npm-audit-report": "^1.3.2",
         "npm-cache-filename": "~1.0.2",
-        "npm-install-checks": "~3.0.0",
-        "npm-lifecycle": "^2.1.0",
-        "npm-package-arg": "^6.1.0",
-        "npm-packlist": "^1.1.12",
-        "npm-pick-manifest": "^2.1.0",
-        "npm-profile": "^3.0.2",
-        "npm-registry-client": "^8.6.0",
-        "npm-registry-fetch": "^1.1.0",
+        "npm-install-checks": "^3.0.2",
+        "npm-lifecycle": "^3.1.4",
+        "npm-package-arg": "^6.1.1",
+        "npm-packlist": "^1.4.4",
+        "npm-pick-manifest": "^3.0.2",
+        "npm-profile": "^4.0.2",
+        "npm-registry-fetch": "^4.0.0",
         "npm-user-validate": "~1.0.0",
         "npmlog": "~4.1.2",
         "once": "~1.4.0",
         "opener": "^1.5.1",
         "osenv": "^0.1.5",
-        "pacote": "^8.1.6",
+        "pacote": "^9.5.8",
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
-        "query-string": "^6.1.0",
+        "query-string": "^6.8.2",
         "qw": "~1.0.1",
         "read": "~1.0.7",
-        "read-cmd-shim": "~1.0.1",
+        "read-cmd-shim": "^1.0.4",
         "read-installed": "~4.0.3",
-        "read-package-json": "^2.0.13",
-        "read-package-tree": "^5.2.1",
-        "readable-stream": "^2.3.6",
-        "readdir-scoped-modules": "*",
+        "read-package-json": "^2.1.0",
+        "read-package-tree": "^5.3.1",
+        "readable-stream": "^3.4.0",
+        "readdir-scoped-modules": "^1.1.0",
         "request": "^2.88.0",
         "retry": "^0.12.0",
-        "rimraf": "~2.6.2",
+        "rimraf": "^2.6.3",
         "safe-buffer": "^5.1.2",
-        "semver": "^5.5.1",
-        "sha": "~2.0.1",
+        "semver": "^5.7.1",
+        "sha": "^3.0.0",
         "slide": "~1.1.6",
         "sorted-object": "~2.0.1",
         "sorted-union-stream": "~2.1.3",
         "ssri": "^6.0.1",
-        "stringify-package": "^1.0.0",
-        "tar": "^4.4.8",
+        "stringify-package": "^1.0.1",
+        "tar": "^4.4.12",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "uid-number": "0.0.6",
         "umask": "~1.1.0",
-        "unique-filename": "~1.1.0",
+        "unique-filename": "^1.1.1",
         "unpipe": "~1.0.0",
         "update-notifier": "^2.5.0",
         "uuid": "^3.3.2",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "~3.0.0",
         "which": "^1.3.1",
-        "worker-farm": "^1.6.0",
-        "write-file-atomic": "^2.3.0"
+        "worker-farm": "^1.7.0",
+        "write-file-atomic": "^2.4.3"
       },
       "dependencies": {
         "JSONStream": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.4.tgz",
-          "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
+          "version": "1.3.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "jsonparse": "^1.2.0",
@@ -7115,23 +3802,20 @@
         },
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+          "bundled": true,
           "dev": true
         },
         "agent-base": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
-          "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+          "version": "4.3.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "es6-promisify": "^5.0.0"
           }
         },
         "agentkeepalive": {
-          "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.4.1.tgz",
-          "integrity": "sha512-MPIwsZU9PP9kOrZpyu2042kYA8Fdt/AedQYkYXucHgF9QoD9dXVp0ypuGnHXSR0hTstBxdt85Xkh4JolYfK5wg==",
+          "version": "3.5.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "humanize-ms": "^1.2.1"
@@ -7139,8 +3823,7 @@
         },
         "ajv": {
           "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "co": "^4.6.0",
@@ -7151,8 +3834,7 @@
         },
         "ansi-align": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "string-width": "^2.0.0"
@@ -7160,14 +3842,12 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "bundled": true,
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -7175,48 +3855,65 @@
         },
         "ansicolors": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+          "bundled": true,
           "dev": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
-          "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
+          "bundled": true,
           "dev": true
         },
         "aproba": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+          "bundled": true,
           "dev": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "asap": {
           "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-          "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+          "bundled": true,
           "dev": true
         },
         "asn1": {
           "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-          "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "safer-buffer": "~2.1.0"
@@ -7224,38 +3921,32 @@
         },
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "bundled": true,
           "dev": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+          "bundled": true,
           "dev": true
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+          "bundled": true,
           "dev": true
         },
         "aws4": {
           "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+          "bundled": true,
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "bundled": true,
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-          "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7263,28 +3954,25 @@
           }
         },
         "bin-links": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.2.tgz",
-          "integrity": "sha512-8eEHVgYP03nILphilltWjeIjMbKyJo3wvp9K816pHbhP301ismzw15mxAAEVQ/USUwcP++1uNrbERbp8lOA6Fg==",
+          "version": "1.1.3",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.0",
-            "cmd-shim": "^2.0.2",
-            "gentle-fs": "^2.0.0",
-            "graceful-fs": "^4.1.11",
+            "bluebird": "^3.5.3",
+            "cmd-shim": "^3.0.0",
+            "gentle-fs": "^2.0.1",
+            "graceful-fs": "^4.1.15",
             "write-file-atomic": "^2.3.0"
           }
         },
         "bluebird": {
-          "version": "3.5.3",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-          "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+          "version": "3.5.5",
+          "bundled": true,
           "dev": true
         },
         "boxen": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-          "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-align": "^2.0.0",
@@ -7298,8 +3986,7 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -7308,84 +3995,69 @@
         },
         "buffer-from": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-          "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
-          "dev": true
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+          "bundled": true,
           "dev": true
         },
         "builtins": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-          "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
+          "bundled": true,
           "dev": true
         },
         "byline": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-          "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
+          "bundled": true,
           "dev": true
         },
         "byte-size": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-4.0.3.tgz",
-          "integrity": "sha512-JGC3EV2bCzJH/ENSh3afyJrH4vwxbHTuO5ljLoI5+2iJOcEpMgP8T782jH9b5qGxf2mSUIp1lfGnfKNrRHpvVg==",
+          "version": "5.0.1",
+          "bundled": true,
           "dev": true
         },
         "cacache": {
-          "version": "11.2.0",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.2.0.tgz",
-          "integrity": "sha512-IFWl6lfK6wSeYCHUXh+N1lY72UDrpyrYQJNIVQf48paDuWbv5RbAtJYf/4gUQFObTCHZwdZ5sI8Iw7nqwP6nlQ==",
+          "version": "12.0.3",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "chownr": "^1.0.1",
-            "figgy-pudding": "^3.1.0",
-            "glob": "^7.1.2",
-            "graceful-fs": "^4.1.11",
-            "lru-cache": "^4.1.3",
+            "bluebird": "^3.5.5",
+            "chownr": "^1.1.1",
+            "figgy-pudding": "^3.5.1",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.1.15",
+            "infer-owner": "^1.0.3",
+            "lru-cache": "^5.1.1",
             "mississippi": "^3.0.0",
             "mkdirp": "^0.5.1",
             "move-concurrently": "^1.0.1",
             "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.2",
-            "ssri": "^6.0.0",
-            "unique-filename": "^1.1.0",
+            "rimraf": "^2.6.3",
+            "ssri": "^6.0.1",
+            "unique-filename": "^1.1.1",
             "y18n": "^4.0.0"
           }
         },
         "call-limit": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.0.tgz",
-          "integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o=",
+          "version": "1.1.1",
+          "bundled": true,
           "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "bundled": true,
           "dev": true
         },
         "capture-stack-trace": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-          "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+          "bundled": true,
           "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+          "bundled": true,
           "dev": true
         },
         "chalk": {
           "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -7394,21 +4066,18 @@
           }
         },
         "chownr": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+          "version": "1.1.2",
+          "bundled": true,
           "dev": true
         },
         "ci-info": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-          "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "cidr-regex": {
-          "version": "2.0.9",
-          "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-2.0.9.tgz",
-          "integrity": "sha512-F7/fBRUU45FnvSPjXdpIrc++WRSBdCiSTlyq4ZNhLKOlHFNWgtzZ0Fd+zrqI/J1j0wmlx/f5ZQDmD2GcbrNcmw==",
+          "version": "2.0.10",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ip-regex": "^2.1.0"
@@ -7416,14 +4085,12 @@
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-          "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+          "bundled": true,
           "dev": true
         },
         "cli-columns": {
           "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/cli-columns/-/cli-columns-3.1.2.tgz",
-          "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "string-width": "^2.0.0",
@@ -7431,9 +4098,8 @@
           }
         },
         "cli-table3": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.0.tgz",
-          "integrity": "sha512-c7YHpUyO1SaKaO7kYtxd5NZ8FjAmSK3LpKkuzdwn+2CwpFxBpdoQLm+OAnnCfoEl7onKhN9PKQi1lsHuAIUqGQ==",
+          "version": "0.5.1",
+          "bundled": true,
           "dev": true,
           "requires": {
             "colors": "^1.1.2",
@@ -7443,8 +4109,7 @@
         },
         "cliui": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "string-width": "^2.1.1",
@@ -7454,14 +4119,12 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "bundled": true,
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -7471,14 +4134,12 @@
         },
         "clone": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+          "bundled": true,
           "dev": true
         },
         "cmd-shim": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
-          "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
+          "version": "3.0.3",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -7487,20 +4148,17 @@
         },
         "co": {
           "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+          "bundled": true,
           "dev": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "dev": true
         },
         "color-convert": {
           "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-          "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "color-name": "^1.1.1"
@@ -7508,21 +4166,18 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "bundled": true,
           "dev": true
         },
         "colors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+          "version": "1.3.3",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "columnify": {
           "version": "1.5.4",
-          "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
-          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "strip-ansi": "^3.0.0",
@@ -7531,8 +4186,7 @@
         },
         "combined-stream": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "delayed-stream": "~1.0.0"
@@ -7540,26 +4194,47 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "bundled": true,
           "dev": true
         },
         "concat-stream": {
           "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
             "inherits": "^2.0.3",
             "readable-stream": "^2.2.2",
             "typedarray": "^0.0.6"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "config-chain": {
           "version": "1.1.12",
-          "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
-          "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ini": "^1.3.4",
@@ -7568,8 +4243,7 @@
         },
         "configstore": {
           "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
-          "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "dot-prop": "^4.1.0",
@@ -7582,14 +4256,12 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "bundled": true,
           "dev": true
         },
         "copy-concurrently": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-          "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^1.1.1",
@@ -7600,24 +4272,26 @@
             "run-queue": "^1.0.0"
           },
           "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
             "iferr": {
               "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "bundled": true,
           "dev": true
         },
         "create-error-class": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "capture-stack-trace": "^1.0.0"
@@ -7625,31 +4299,43 @@
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "4.1.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
+              }
+            },
+            "yallist": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+          "bundled": true,
           "dev": true
         },
         "cyclist": {
           "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-          "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+          "bundled": true,
           "dev": true
         },
         "dashdash": {
           "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
@@ -7657,8 +4343,7 @@
         },
         "debug": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -7666,73 +4351,70 @@
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-          "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+          "bundled": true,
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "bundled": true,
           "dev": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+          "bundled": true,
           "dev": true
         },
         "deep-extend": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+          "bundled": true,
           "dev": true
         },
         "defaults": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-          "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "clone": "^1.0.2"
           }
         },
+        "define-properties": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
         "delayed-stream": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+          "bundled": true,
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "bundled": true,
           "dev": true
         },
         "detect-indent": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
+          "bundled": true,
           "dev": true
         },
         "detect-newline": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-          "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+          "bundled": true,
           "dev": true
         },
         "dezalgo": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-          "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "asap": "^2.0.0",
@@ -7741,8 +4423,7 @@
         },
         "dot-prop": {
           "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-obj": "^1.0.0"
@@ -7750,32 +4431,52 @@
         },
         "dotenv": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
-          "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
+          "bundled": true,
           "dev": true
         },
         "duplexer3": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+          "bundled": true,
           "dev": true
         },
         "duplexify": {
           "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
-          "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "end-of-stream": "^1.0.0",
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.0",
             "stream-shift": "^1.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "ecc-jsbn": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-          "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7785,14 +4486,12 @@
         },
         "editor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
-          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
+          "bundled": true,
           "dev": true
         },
         "encoding": {
           "version": "0.1.12",
-          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "iconv-lite": "~0.4.13"
@@ -7800,38 +4499,60 @@
         },
         "end-of-stream": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-          "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "once": "^1.4.0"
           }
         },
+        "env-paths": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
         "err-code": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
+          "bundled": true,
           "dev": true
         },
         "errno": {
           "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-          "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "prr": "~1.0.1"
           }
         },
+        "es-abstract": {
+          "version": "1.12.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.1.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.1",
+            "is-callable": "^1.1.3",
+            "is-regex": "^1.0.4"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
         "es6-promise": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+          "version": "4.2.8",
+          "bundled": true,
           "dev": true
         },
         "es6-promisify": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "es6-promise": "^4.0.3"
@@ -7839,14 +4560,12 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "bundled": true,
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -7856,48 +4575,48 @@
             "p-finally": "^1.0.0",
             "signal-exit": "^3.0.0",
             "strip-eof": "^1.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "extend": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+          "bundled": true,
           "dev": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+          "bundled": true,
           "dev": true
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "bundled": true,
           "dev": true
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-          "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+          "bundled": true,
           "dev": true
         },
         "figgy-pudding": {
           "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-          "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+          "bundled": true,
           "dev": true
         },
         "find-npm-prefix": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz",
-          "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
+          "bundled": true,
           "dev": true
         },
         "find-up": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
@@ -7905,24 +4624,45 @@
         },
         "flush-write-stream": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-          "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.4"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "forever-agent": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+          "bundled": true,
           "dev": true
         },
         "form-data": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
@@ -7932,27 +4672,59 @@
         },
         "from2": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-          "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "fs-minipass": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+          "version": "1.2.7",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "2.8.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            }
           }
         },
         "fs-vacuum": {
           "version": "1.2.10",
-          "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
-          "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -7962,8 +4734,7 @@
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
-          "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -7974,22 +4745,46 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+              "bundled": true,
               "dev": true
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
             }
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
+          "dev": true
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "bundled": true,
           "dev": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^1.0.3",
@@ -8002,10 +4797,14 @@
             "wide-align": "^1.1.0"
           },
           "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -8016,60 +4815,63 @@
           }
         },
         "genfun": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/genfun/-/genfun-4.0.1.tgz",
-          "integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E=",
+          "version": "5.0.0",
+          "bundled": true,
           "dev": true
         },
         "gentle-fs": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.0.1.tgz",
-          "integrity": "sha512-cEng5+3fuARewXktTEGbwsktcldA+YsnUEaXZwcK/3pjSE1X9ObnTs+/8rYf8s+RnIcQm2D5x3rwpN7Zom8Bew==",
+          "version": "2.2.1",
+          "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^1.1.2",
+            "chownr": "^1.1.2",
             "fs-vacuum": "^1.2.10",
             "graceful-fs": "^4.1.11",
             "iferr": "^0.1.5",
+            "infer-owner": "^1.0.4",
             "mkdirp": "^0.5.1",
             "path-is-inside": "^1.0.2",
             "read-cmd-shim": "^1.0.1",
             "slide": "^1.1.6"
           },
           "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
             "iferr": {
               "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+          "bundled": true,
           "dev": true
         },
         "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
         },
         "getpass": {
           "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
           }
         },
         "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "version": "7.1.4",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -8082,8 +4884,7 @@
         },
         "global-dirs": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-          "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ini": "^1.3.4"
@@ -8091,8 +4892,7 @@
         },
         "got": {
           "version": "6.7.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "create-error-class": "^3.0.0",
@@ -8106,58 +4906,70 @@
             "timed-out": "^4.0.0",
             "unzip-response": "^2.0.1",
             "url-parse-lax": "^1.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "graceful-fs": {
-          "version": "4.1.15",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+          "version": "4.2.2",
+          "bundled": true,
           "dev": true
         },
         "har-schema": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+          "bundled": true,
           "dev": true
         },
         "har-validator": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-          "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ajv": "^5.3.0",
             "har-schema": "^2.0.0"
           }
         },
+        "has": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "bundled": true,
+          "dev": true
+        },
+        "has-symbols": {
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "bundled": true,
           "dev": true
         },
         "hosted-git-info": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-          "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+          "version": "2.8.5",
+          "bundled": true,
           "dev": true
         },
         "http-cache-semantics": {
           "version": "3.8.1",
-          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-          "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+          "bundled": true,
           "dev": true
         },
         "http-proxy-agent": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-          "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "agent-base": "4",
@@ -8166,8 +4978,7 @@
         },
         "http-signature": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
@@ -8176,19 +4987,17 @@
           }
         },
         "https-proxy-agent": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-          "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+          "version": "2.2.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "^4.1.0",
+            "agent-base": "^4.3.0",
             "debug": "^3.1.0"
           }
         },
         "humanize-ms": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-          "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ms": "^2.0.0"
@@ -8196,8 +5005,7 @@
         },
         "iconv-lite": {
           "version": "0.4.23",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -8205,14 +5013,12 @@
         },
         "iferr": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/iferr/-/iferr-1.0.2.tgz",
-          "integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==",
+          "bundled": true,
           "dev": true
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -8220,20 +5026,22 @@
         },
         "import-lazy": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-          "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+          "bundled": true,
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+          "bundled": true,
+          "dev": true
+        },
+        "infer-owner": {
+          "version": "1.0.4",
+          "bundled": true,
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -8241,21 +5049,18 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "version": "2.0.4",
+          "bundled": true,
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+          "bundled": true,
           "dev": true
         },
         "init-package-json": {
           "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
-          "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^7.1.1",
@@ -8270,53 +5075,55 @@
         },
         "invert-kv": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "bundled": true,
           "dev": true
         },
         "ip": {
           "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+          "bundled": true,
           "dev": true
         },
         "ip-regex": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-          "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+          "bundled": true,
           "dev": true
         },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-          "dev": true,
-          "requires": {
-            "builtin-modules": "^1.0.0"
-          }
+        "is-callable": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true
         },
         "is-ci": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-          "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ci-info": "^1.0.0"
+          },
+          "dependencies": {
+            "ci-info": {
+              "version": "1.6.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "is-cidr": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-2.0.6.tgz",
-          "integrity": "sha512-A578p1dV22TgPXn6NCaDAPj6vJvYsBgAzUrAd28a4oldeXJjWqEUuSZOLIW3im51mazOKsoyVp8NU/OItlWacw==",
+          "version": "3.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "cidr-regex": "^2.0.8"
+            "cidr-regex": "^2.0.10"
           }
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -8324,8 +5131,7 @@
         },
         "is-installed-globally": {
           "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-          "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "global-dirs": "^0.1.0",
@@ -8334,20 +5140,17 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-          "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+          "bundled": true,
           "dev": true
         },
         "is-obj": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+          "bundled": true,
           "dev": true
         },
         "is-path-inside": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "path-is-inside": "^1.0.1"
@@ -8355,87 +5158,89 @@
         },
         "is-redirect": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+          "bundled": true,
           "dev": true
+        },
+        "is-regex": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "has": "^1.0.1"
+          }
         },
         "is-retry-allowed": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-          "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+          "bundled": true,
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "bundled": true,
           "dev": true
+        },
+        "is-symbol": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.0"
+          }
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+          "bundled": true,
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "bundled": true,
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+          "bundled": true,
           "dev": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-          "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+          "bundled": true,
           "dev": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+          "bundled": true,
           "dev": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "bundled": true,
           "dev": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+          "bundled": true,
           "dev": true
         },
         "jsonparse": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-          "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+          "bundled": true,
           "dev": true
         },
         "jsprim": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "assert-plus": "1.0.0",
@@ -8446,8 +5251,7 @@
         },
         "latest-version": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "package-json": "^4.0.0"
@@ -8455,70 +5259,189 @@
         },
         "lazy-property": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
-          "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
+          "bundled": true,
           "dev": true
         },
         "lcid": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "invert-kv": "^1.0.0"
           }
         },
         "libcipm": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/libcipm/-/libcipm-2.0.2.tgz",
-          "integrity": "sha512-9uZ6/LAflVEijksTRq/RX0e+pGA4mr8tND9Cmk2JMg7j2fFUBrs8PpFX2DOAJR/XoxPzz+5h8bkWmtIYLunKAg==",
+          "version": "4.0.4",
+          "bundled": true,
           "dev": true,
           "requires": {
             "bin-links": "^1.1.2",
             "bluebird": "^3.5.1",
+            "figgy-pudding": "^3.5.1",
             "find-npm-prefix": "^1.0.2",
             "graceful-fs": "^4.1.11",
+            "ini": "^1.3.5",
             "lock-verify": "^2.0.2",
             "mkdirp": "^0.5.1",
-            "npm-lifecycle": "^2.0.3",
+            "npm-lifecycle": "^3.0.0",
             "npm-logical-tree": "^1.2.1",
             "npm-package-arg": "^6.1.0",
-            "pacote": "^8.1.6",
-            "protoduck": "^5.0.0",
+            "pacote": "^9.1.0",
             "read-package-json": "^2.0.13",
             "rimraf": "^2.6.2",
             "worker-farm": "^1.6.0"
           }
         },
-        "libnpmhook": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/libnpmhook/-/libnpmhook-4.0.1.tgz",
-          "integrity": "sha512-3qqpfqvBD1712WA6iGe0stkG40WwAeoWcujA6BlC0Be1JArQbqwabnEnZ0CRcD05Tf1fPYJYdCbSfcfedEJCOg==",
+        "libnpm": {
+          "version": "3.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "figgy-pudding": "^3.1.0",
-            "npm-registry-fetch": "^3.0.0"
+            "bin-links": "^1.1.2",
+            "bluebird": "^3.5.3",
+            "find-npm-prefix": "^1.0.2",
+            "libnpmaccess": "^3.0.2",
+            "libnpmconfig": "^1.2.1",
+            "libnpmhook": "^5.0.3",
+            "libnpmorg": "^1.0.1",
+            "libnpmpublish": "^1.1.2",
+            "libnpmsearch": "^2.0.2",
+            "libnpmteam": "^1.0.2",
+            "lock-verify": "^2.0.2",
+            "npm-lifecycle": "^3.0.0",
+            "npm-logical-tree": "^1.2.1",
+            "npm-package-arg": "^6.1.0",
+            "npm-profile": "^4.0.2",
+            "npm-registry-fetch": "^4.0.0",
+            "npmlog": "^4.1.2",
+            "pacote": "^9.5.3",
+            "read-package-json": "^2.0.13",
+            "stringify-package": "^1.0.0"
+          }
+        },
+        "libnpmaccess": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "get-stream": "^4.0.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
+        "libnpmconfig": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1",
+            "find-up": "^3.0.0",
+            "ini": "^1.3.5"
           },
           "dependencies": {
-            "npm-registry-fetch": {
-              "version": "3.1.1",
-              "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.1.1.tgz",
-              "integrity": "sha512-xBobENeenvjIG8PgQ1dy77AXTI25IbYhmA3DusMIfw/4EL5BaQ5e1V9trkPrqHvyjR3/T0cnH6o0Wt/IzcI5Ag==",
+            "find-up": {
+              "version": "3.0.0",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "bluebird": "^3.5.1",
-                "figgy-pudding": "^3.1.0",
-                "lru-cache": "^4.1.2",
-                "make-fetch-happen": "^4.0.0",
-                "npm-package-arg": "^6.0.0"
+                "locate-path": "^3.0.0"
               }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.2.0",
+              "bundled": true,
+              "dev": true
             }
+          }
+        },
+        "libnpmhook": {
+          "version": "5.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
+        "libnpmorg": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
+        "libnpmpublish": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.0.0",
+            "lodash.clonedeep": "^4.5.0",
+            "normalize-package-data": "^2.4.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-registry-fetch": "^4.0.0",
+            "semver": "^5.5.1",
+            "ssri": "^6.0.1"
+          }
+        },
+        "libnpmsearch": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
+        "libnpmteam": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpx": {
           "version": "10.2.0",
-          "resolved": "https://registry.npmjs.org/libnpx/-/libnpx-10.2.0.tgz",
-          "integrity": "sha512-X28coei8/XRCt15cYStbLBph+KGhFra4VQhRBPuH/HHMkC5dxM8v24RVgUsvODKCrUZ0eTgiTqJp6zbl0sskQQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "dotenv": "^5.0.1",
@@ -8533,8 +5456,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
@@ -8542,19 +5464,17 @@
           }
         },
         "lock-verify": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lock-verify/-/lock-verify-2.0.2.tgz",
-          "integrity": "sha512-QNVwK0EGZBS4R3YQ7F1Ox8p41Po9VGl2QG/2GsuvTbkJZYSsPeWHKMbbH6iZMCHWSMww5nrJroZYnGzI4cePuw==",
+          "version": "2.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "npm-package-arg": "^5.1.2 || 6",
+            "npm-package-arg": "^6.1.0",
             "semver": "^5.4.1"
           }
         },
         "lockfile": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
-          "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "signal-exit": "^3.0.2"
@@ -8562,14 +5482,12 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
-          "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
+          "bundled": true,
           "dev": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
-          "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lodash._createset": "~4.0.0",
@@ -8578,20 +5496,17 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+          "bundled": true,
           "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
-          "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
+          "bundled": true,
           "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
-          "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
@@ -8599,89 +5514,76 @@
         },
         "lodash._createset": {
           "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
-          "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
+          "bundled": true,
           "dev": true
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+          "bundled": true,
           "dev": true
         },
         "lodash._root": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-          "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+          "bundled": true,
           "dev": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-          "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+          "bundled": true,
           "dev": true
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+          "bundled": true,
           "dev": true
         },
         "lodash.union": {
           "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-          "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
+          "bundled": true,
           "dev": true
         },
         "lodash.uniq": {
           "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-          "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+          "bundled": true,
           "dev": true
         },
         "lodash.without": {
           "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
-          "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
+          "bundled": true,
           "dev": true
         },
         "lowercase-keys": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+          "bundled": true,
           "dev": true
         },
         "lru-cache": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+          "version": "5.1.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "yallist": "^3.0.2"
           }
         },
         "make-dir": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "pify": "^3.0.0"
           }
         },
         "make-fetch-happen": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-4.0.1.tgz",
-          "integrity": "sha512-7R5ivfy9ilRJ1EMKIOziwrns9fGeAD4bAha8EB7BIiBBLHm2KeTUGCrICFt2rbHfzheTLynv50GnNTK1zDTrcQ==",
+          "version": "5.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "agentkeepalive": "^3.4.1",
-            "cacache": "^11.0.1",
+            "cacache": "^12.0.0",
             "http-cache-semantics": "^3.8.1",
             "http-proxy-agent": "^2.1.0",
             "https-proxy-agent": "^2.2.1",
-            "lru-cache": "^4.1.2",
+            "lru-cache": "^5.1.1",
             "mississippi": "^3.0.0",
             "node-fetch-npm": "^2.0.2",
             "promise-retry": "^1.1.1",
@@ -8691,14 +5593,12 @@
         },
         "meant": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/meant/-/meant-1.0.1.tgz",
-          "integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg==",
+          "bundled": true,
           "dev": true
         },
         "mem": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mimic-fn": "^1.0.0"
@@ -8706,14 +5606,12 @@
         },
         "mime-db": {
           "version": "1.35.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-          "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
+          "bundled": true,
           "dev": true
         },
         "mime-types": {
           "version": "2.1.19",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
-          "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mime-db": "~1.35.0"
@@ -8721,14 +5619,12 @@
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "bundled": true,
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -8736,14 +5632,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "bundled": true,
           "dev": true
         },
         "minipass": {
           "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
-          "integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -8752,16 +5646,14 @@
           "dependencies": {
             "yallist": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-              "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "minizlib": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.1.tgz",
-          "integrity": "sha512-TrfjCjk4jLhcJyGMYymBH6oTXcWjYbUAXTHDbtnWHjZC25h0cdajHuPE1zxb4DVmu8crfh+HwH/WMuyLG0nHBg==",
+          "version": "1.2.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -8769,8 +5661,7 @@
         },
         "mississippi": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-          "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "concat-stream": "^1.5.0",
@@ -8787,8 +5678,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -8796,8 +5686,7 @@
         },
         "move-concurrently": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
-          "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^1.1.1",
@@ -8806,24 +5695,28 @@
             "mkdirp": "^0.5.1",
             "rimraf": "^2.5.4",
             "run-queue": "^1.0.3"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "bundled": true,
           "dev": true
         },
         "mute-stream": {
           "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+          "bundled": true,
           "dev": true
         },
         "node-fetch-npm": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
-          "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "encoding": "^0.1.11",
@@ -8832,41 +5725,26 @@
           }
         },
         "node-gyp": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
-          "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+          "version": "5.0.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "fstream": "^1.0.0",
+            "env-paths": "^1.0.0",
             "glob": "^7.0.3",
             "graceful-fs": "^4.1.2",
             "mkdirp": "^0.5.0",
             "nopt": "2 || 3",
             "npmlog": "0 || 1 || 2 || 3 || 4",
-            "osenv": "0",
             "request": "^2.87.0",
             "rimraf": "2",
             "semver": "~5.3.0",
-            "tar": "^2.0.0",
+            "tar": "^4.4.12",
             "which": "1"
           },
           "dependencies": {
-            "fstream": {
-              "version": "1.0.12",
-              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-              "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
-              }
-            },
             "nopt": {
               "version": "3.0.6",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "abbrev": "1"
@@ -8874,38 +5752,14 @@
             },
             "semver": {
               "version": "5.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+              "bundled": true,
               "dev": true
-            },
-            "tar": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-              "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
-              "dev": true,
-              "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.12",
-                "inherits": "2"
-              },
-              "dependencies": {
-                "block-stream": {
-                  "version": "0.0.9",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-                  "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-                  "dev": true,
-                  "requires": {
-                    "inherits": "~2.0.0"
-                  }
-                }
-              }
             }
           }
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "abbrev": "1",
@@ -8913,21 +5767,29 @@
           }
         },
         "normalize-package-data": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+          "version": "2.5.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
+            "resolve": "^1.10.0",
             "semver": "2 || 3 || 4 || 5",
             "validate-npm-package-license": "^3.0.1"
+          },
+          "dependencies": {
+            "resolve": {
+              "version": "1.10.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-parse": "^1.0.6"
+              }
+            }
           }
         },
         "npm-audit-report": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/npm-audit-report/-/npm-audit-report-1.3.1.tgz",
-          "integrity": "sha512-SjTF8ZP4rOu3JiFrTMi4M1CmVo2tni2sP4TzhyCMHwnMGf6XkdGLZKt9cdZ12esKf0mbQqFyU9LtY0SoeahL7g==",
+          "version": "1.3.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cli-table3": "^0.5.0",
@@ -8935,35 +5797,31 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
-          "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
+          "version": "1.0.6",
+          "bundled": true,
           "dev": true
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
-          "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
+          "bundled": true,
           "dev": true
         },
         "npm-install-checks": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
-          "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
+          "version": "3.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "semver": "^2.3.0 || 3.x || 4 || 5"
           }
         },
         "npm-lifecycle": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-2.1.0.tgz",
-          "integrity": "sha512-QbBfLlGBKsktwBZLj6AviHC6Q9Y3R/AY4a2PYSIRhSKSS0/CxRyD/PfxEX6tPeOCXQgMSNdwGeECacstgptc+g==",
+          "version": "3.1.4",
+          "bundled": true,
           "dev": true,
           "requires": {
             "byline": "^5.0.0",
-            "graceful-fs": "^4.1.11",
-            "node-gyp": "^3.8.0",
+            "graceful-fs": "^4.1.15",
+            "node-gyp": "^5.0.2",
             "resolve-from": "^4.0.0",
             "slide": "^1.1.6",
             "uid-number": "0.0.6",
@@ -8973,26 +5831,23 @@
         },
         "npm-logical-tree": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz",
-          "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
+          "bundled": true,
           "dev": true
         },
         "npm-package-arg": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
-          "integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
+          "version": "6.1.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "^2.6.0",
+            "hosted-git-info": "^2.7.1",
             "osenv": "^0.1.5",
-            "semver": "^5.5.0",
+            "semver": "^5.6.0",
             "validate-npm-package-name": "^3.0.0"
           }
         },
         "npm-packlist": {
-          "version": "1.1.12",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.12.tgz",
-          "integrity": "sha512-WJKFOVMeAlsU/pjXuqVdzU0WfgtIBCupkEVwn+1Y0ERAbUfWw8R4GjgVbaKnUjRoD2FoQbHOCbOyT5Mbs9Lw4g==",
+          "version": "1.4.4",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -9000,193 +5855,41 @@
           }
         },
         "npm-pick-manifest": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-2.1.0.tgz",
-          "integrity": "sha512-q9zLP8cTr8xKPmMZN3naxp1k/NxVFsjxN6uWuO1tiw9gxg7wZWQ/b5UTfzD0ANw2q1lQxdLKTeCCksq+bPSgbQ==",
+          "version": "3.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
+            "figgy-pudding": "^3.5.1",
             "npm-package-arg": "^6.0.0",
             "semver": "^5.4.1"
           }
         },
         "npm-profile": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-3.0.2.tgz",
-          "integrity": "sha512-rEJOFR6PbwOvvhGa2YTNOJQKNuc6RovJ6T50xPU7pS9h/zKPNCJ+VHZY2OFXyZvEi+UQYtHRTp8O/YM3tUD20A==",
+          "version": "4.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^1.1.2 || 2",
-            "make-fetch-happen": "^2.5.0 || 3 || 4"
-          }
-        },
-        "npm-registry-client": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.6.0.tgz",
-          "integrity": "sha512-Qs6P6nnopig+Y8gbzpeN/dkt+n7IyVd8f45NTMotGk6Qo7GfBmzwYx6jRLoOOgKiMnaQfYxsuyQlD8Mc3guBhg==",
-          "dev": true,
-          "requires": {
-            "concat-stream": "^1.5.2",
-            "graceful-fs": "^4.1.6",
-            "normalize-package-data": "~1.0.1 || ^2.0.0",
-            "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-            "npmlog": "2 || ^3.1.0 || ^4.0.0",
-            "once": "^1.3.3",
-            "request": "^2.74.0",
-            "retry": "^0.10.0",
-            "safe-buffer": "^5.1.1",
-            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-            "slide": "^1.1.3",
-            "ssri": "^5.2.4"
-          },
-          "dependencies": {
-            "retry": {
-              "version": "0.10.1",
-              "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-              "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
-              "dev": true
-            },
-            "ssri": {
-              "version": "5.3.0",
-              "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
-              "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
-              "dev": true,
-              "requires": {
-                "safe-buffer": "^5.1.1"
-              }
-            }
+            "figgy-pudding": "^3.4.1",
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-1.1.0.tgz",
-          "integrity": "sha512-XJPIBfMtgaooRtZmuA42xCeLf3tkxdIX0xqRsGWwNrcVvJ9UYFccD7Ho7QWCzvkM3i/QrkUC37Hu0a+vDBmt5g==",
+          "version": "4.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
+            "JSONStream": "^1.3.4",
             "bluebird": "^3.5.1",
-            "figgy-pudding": "^2.0.1",
-            "lru-cache": "^4.1.2",
-            "make-fetch-happen": "^3.0.0",
-            "npm-package-arg": "^6.0.0",
-            "safe-buffer": "^5.1.1"
-          },
-          "dependencies": {
-            "cacache": {
-              "version": "10.0.4",
-              "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
-              "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
-              "dev": true,
-              "requires": {
-                "bluebird": "^3.5.1",
-                "chownr": "^1.0.1",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^2.0.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.2",
-                "ssri": "^5.2.4",
-                "unique-filename": "^1.1.0",
-                "y18n": "^4.0.0"
-              },
-              "dependencies": {
-                "mississippi": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
-                  "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
-                  "dev": true,
-                  "requires": {
-                    "concat-stream": "^1.5.0",
-                    "duplexify": "^3.4.2",
-                    "end-of-stream": "^1.1.0",
-                    "flush-write-stream": "^1.0.0",
-                    "from2": "^2.1.0",
-                    "parallel-transform": "^1.1.0",
-                    "pump": "^2.0.1",
-                    "pumpify": "^1.3.3",
-                    "stream-each": "^1.1.0",
-                    "through2": "^2.0.0"
-                  }
-                }
-              }
-            },
-            "figgy-pudding": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-2.0.1.tgz",
-              "integrity": "sha512-yIJPhIBi/oFdU/P+GSXjmk/rmGjuZkm7A5LTXZxNrEprXJXRK012FiI1BR1Pga+0d/d6taWWD+B5d2ozqaxHig==",
-              "dev": true
-            },
-            "make-fetch-happen": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-3.0.0.tgz",
-              "integrity": "sha512-FmWY7gC0mL6Z4N86vE14+m719JKE4H0A+pyiOH18B025gF/C113pyfb4gHDDYP5cqnRMHOz06JGdmffC/SES+w==",
-              "dev": true,
-              "requires": {
-                "agentkeepalive": "^3.4.1",
-                "cacache": "^10.0.4",
-                "http-cache-semantics": "^3.8.1",
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.0",
-                "lru-cache": "^4.1.2",
-                "mississippi": "^3.0.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^3.0.1",
-                "ssri": "^5.2.4"
-              }
-            },
-            "pump": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-              "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-              "dev": true,
-              "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-              }
-            },
-            "smart-buffer": {
-              "version": "1.1.15",
-              "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
-              "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
-              "dev": true
-            },
-            "socks": {
-              "version": "1.1.10",
-              "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
-              "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
-              "dev": true,
-              "requires": {
-                "ip": "^1.1.4",
-                "smart-buffer": "^1.0.13"
-              }
-            },
-            "socks-proxy-agent": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
-              "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
-              "dev": true,
-              "requires": {
-                "agent-base": "^4.1.0",
-                "socks": "^1.1.10"
-              }
-            },
-            "ssri": {
-              "version": "5.3.0",
-              "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
-              "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
-              "dev": true,
-              "requires": {
-                "safe-buffer": "^5.1.1"
-              }
-            }
+            "figgy-pudding": "^3.4.1",
+            "lru-cache": "^5.1.1",
+            "make-fetch-happen": "^5.0.0",
+            "npm-package-arg": "^6.1.0"
           }
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "path-key": "^2.0.0"
@@ -9194,14 +5897,12 @@
         },
         "npm-user-validate": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.0.tgz",
-          "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
+          "bundled": true,
           "dev": true
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -9212,26 +5913,36 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "bundled": true,
           "dev": true
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+          "bundled": true,
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "dev": true
+        },
+        "object-keys": {
+          "version": "1.0.12",
+          "bundled": true,
+          "dev": true
+        },
+        "object.getownpropertydescriptors": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.5.1"
+          }
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -9239,20 +5950,17 @@
         },
         "opener": {
           "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
-          "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+          "bundled": true,
           "dev": true
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "execa": "^0.7.0",
@@ -9262,14 +5970,12 @@
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "bundled": true,
           "dev": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -9278,14 +5984,12 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+          "bundled": true,
           "dev": true
         },
         "p-limit": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-          "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-try": "^1.0.0"
@@ -9293,8 +5997,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
@@ -9302,14 +6005,12 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "bundled": true,
           "dev": true
         },
         "package-json": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "got": "^6.7.1",
@@ -9319,107 +6020,139 @@
           }
         },
         "pacote": {
-          "version": "8.1.6",
-          "resolved": "https://registry.npmjs.org/pacote/-/pacote-8.1.6.tgz",
-          "integrity": "sha512-wTOOfpaAQNEQNtPEx92x9Y9kRWVu45v583XT8x2oEV2xRB74+xdqMZIeGW4uFvAyZdmSBtye+wKdyyLaT8pcmw==",
+          "version": "9.5.8",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "cacache": "^11.0.2",
-            "get-stream": "^3.0.0",
-            "glob": "^7.1.2",
-            "lru-cache": "^4.1.3",
-            "make-fetch-happen": "^4.0.1",
+            "bluebird": "^3.5.3",
+            "cacache": "^12.0.2",
+            "chownr": "^1.1.2",
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.1.0",
+            "glob": "^7.1.3",
+            "infer-owner": "^1.0.4",
+            "lru-cache": "^5.1.1",
+            "make-fetch-happen": "^5.0.0",
             "minimatch": "^3.0.4",
-            "minipass": "^2.3.3",
+            "minipass": "^2.3.5",
             "mississippi": "^3.0.0",
             "mkdirp": "^0.5.1",
             "normalize-package-data": "^2.4.0",
             "npm-package-arg": "^6.1.0",
-            "npm-packlist": "^1.1.10",
-            "npm-pick-manifest": "^2.1.0",
+            "npm-packlist": "^1.1.12",
+            "npm-pick-manifest": "^3.0.0",
+            "npm-registry-fetch": "^4.0.0",
             "osenv": "^0.1.5",
             "promise-inflight": "^1.0.1",
             "promise-retry": "^1.1.1",
-            "protoduck": "^5.0.0",
+            "protoduck": "^5.0.1",
             "rimraf": "^2.6.2",
             "safe-buffer": "^5.1.2",
-            "semver": "^5.5.0",
-            "ssri": "^6.0.0",
-            "tar": "^4.4.3",
-            "unique-filename": "^1.1.0",
-            "which": "^1.3.0"
+            "semver": "^5.6.0",
+            "ssri": "^6.0.1",
+            "tar": "^4.4.10",
+            "unique-filename": "^1.1.1",
+            "which": "^1.3.1"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "2.3.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            }
           }
         },
         "parallel-transform": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
-          "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cyclist": "~0.2.2",
             "inherits": "^2.0.3",
             "readable-stream": "^2.1.5"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "bundled": true,
           "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "dev": true
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+          "bundled": true,
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "bundled": true,
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "bundled": true,
           "dev": true
         },
         "performance-now": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+          "bundled": true,
           "dev": true
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "bundled": true,
           "dev": true
         },
         "prepend-http": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+          "bundled": true,
           "dev": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "bundled": true,
           "dev": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-          "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+          "bundled": true,
           "dev": true
         },
         "promise-retry": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
-          "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "err-code": "^1.0.0",
@@ -9428,16 +6161,14 @@
           "dependencies": {
             "retry": {
               "version": "0.10.1",
-              "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-              "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "promzard": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-          "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "read": "1"
@@ -9445,41 +6176,35 @@
         },
         "proto-list": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-          "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+          "bundled": true,
           "dev": true
         },
         "protoduck": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.0.tgz",
-          "integrity": "sha512-agsGWD8/RZrS4ga6v82Fxb0RHIS2RZnbsSue6A9/MBRhB/jcqOANAMNrqM9900b8duj+Gx+T/JMy5IowDoO/hQ==",
+          "version": "5.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "genfun": "^4.0.1"
+            "genfun": "^5.0.0"
           }
         },
         "prr": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-          "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+          "bundled": true,
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+          "bundled": true,
           "dev": true
         },
         "psl": {
           "version": "1.1.29",
-          "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-          "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+          "bundled": true,
           "dev": true
         },
         "pump": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -9488,8 +6213,7 @@
         },
         "pumpify": {
           "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-          "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "duplexify": "^3.6.0",
@@ -9499,8 +6223,7 @@
           "dependencies": {
             "pump": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-              "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "end-of-stream": "^1.1.0",
@@ -9511,42 +6234,37 @@
         },
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "bundled": true,
           "dev": true
         },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
-          "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+          "bundled": true,
           "dev": true
         },
         "qs": {
           "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "bundled": true,
           "dev": true
         },
         "query-string": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.1.0.tgz",
-          "integrity": "sha512-pNB/Gr8SA8ff8KpUFM36o/WFAlthgaThka5bV19AD9PNTH20Pwq5Zxodif2YyHwrctp6SkL4GqlOot0qR/wGaw==",
+          "version": "6.8.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
+            "split-on-first": "^1.0.0",
             "strict-uri-encode": "^2.0.0"
           }
         },
         "qw": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/qw/-/qw-1.0.1.tgz",
-          "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=",
+          "bundled": true,
           "dev": true
         },
         "rc": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-          "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "deep-extend": "^0.5.1",
@@ -9557,25 +6275,22 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "read": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mute-stream": "~0.0.4"
           }
         },
         "read-cmd-shim": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
-          "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
+          "version": "1.0.4",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2"
@@ -9583,8 +6298,7 @@
         },
         "read-installed": {
           "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
-          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -9597,9 +6311,8 @@
           }
         },
         "read-package-json": {
-          "version": "2.0.13",
-          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz",
-          "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
+          "version": "2.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^7.1.1",
@@ -9610,37 +6323,28 @@
           }
         },
         "read-package-tree": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.2.1.tgz",
-          "integrity": "sha512-2CNoRoh95LxY47LvqrehIAfUVda2JbuFE/HaGYs42bNrGG+ojbw1h3zOcPcQ+1GQ3+rkzNndZn85u1XyZ3UsIA==",
+          "version": "5.3.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "once": "^1.3.0",
             "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0"
+            "readdir-scoped-modules": "^1.0.0",
+            "util-promisify": "^2.1.0"
           }
         },
         "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "version": "3.4.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
         "readdir-scoped-modules": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
-          "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -9651,8 +6355,7 @@
         },
         "registry-auth-token": {
           "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
-          "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "rc": "^1.1.6",
@@ -9661,8 +6364,7 @@
         },
         "registry-url": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "rc": "^1.0.1"
@@ -9670,8 +6372,7 @@
         },
         "request": {
           "version": "2.88.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "aws-sign2": "~0.7.0",
@@ -9698,68 +6399,65 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+          "bundled": true,
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "bundled": true,
           "dev": true
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "bundled": true,
           "dev": true
         },
         "retry": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+          "bundled": true,
           "dev": true
         },
         "rimraf": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "version": "2.6.3",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
         "run-queue": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
-          "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^1.1.1"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "bundled": true,
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+          "bundled": true,
           "dev": true
         },
         "semver": {
-          "version": "5.5.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-          "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+          "version": "5.7.1",
+          "bundled": true,
           "dev": true
         },
         "semver-diff": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-          "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "semver": "^5.0.3"
@@ -9767,24 +6465,20 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true
         },
         "sha": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
-          "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
+          "version": "3.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "readable-stream": "^2.0.2"
+            "graceful-fs": "^4.1.2"
           }
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -9792,64 +6486,65 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "bundled": true,
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "dev": true
         },
         "slash": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+          "bundled": true,
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+          "bundled": true,
           "dev": true
         },
         "smart-buffer": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.1.tgz",
-          "integrity": "sha512-RFqinRVJVcCAL9Uh1oVqE6FZkqsyLiVOYEZ20TqIOjuX7iFVJ+zsbs4RIghnw/pTs7mZvt8ZHhvm1ZUrR4fykg==",
+          "version": "4.0.2",
+          "bundled": true,
           "dev": true
         },
         "socks": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/socks/-/socks-2.2.0.tgz",
-          "integrity": "sha512-uRKV9uXQ9ytMbGm2+DilS1jB7N3AC0mmusmW5TVWjNuBZjxS8+lX38fasKVY9I4opv/bY/iqTbcpFFaTwpfwRg==",
+          "version": "2.3.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ip": "^1.1.5",
-            "smart-buffer": "^4.0.1"
+            "smart-buffer": "4.0.2"
           }
         },
         "socks-proxy-agent": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.1.tgz",
-          "integrity": "sha512-Kezx6/VBguXOsEe5oU3lXYyKMi4+gva72TwJ7pQY5JfqUx2nMk7NXA6z/mpNqIlfQjWYVfeuNvQjexiTaTn6Nw==",
+          "version": "4.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "~4.2.0",
-            "socks": "~2.2.0"
+            "agent-base": "~4.2.1",
+            "socks": "~2.3.2"
+          },
+          "dependencies": {
+            "agent-base": {
+              "version": "4.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "es6-promisify": "^5.0.0"
+              }
+            }
           }
         },
         "sorted-object": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
-          "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
+          "bundled": true,
           "dev": true
         },
         "sorted-union-stream": {
           "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
-          "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "from2": "^1.3.0",
@@ -9858,8 +6553,7 @@
           "dependencies": {
             "from2": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
-              "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "inherits": "~2.0.1",
@@ -9868,14 +6562,12 @@
             },
             "isarray": {
               "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+              "bundled": true,
               "dev": true
             },
             "readable-stream": {
               "version": "1.1.14",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -9886,16 +6578,14 @@
             },
             "string_decoder": {
               "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "spdx-correct": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
@@ -9904,14 +6594,12 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-          "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+          "bundled": true,
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
@@ -9919,15 +6607,18 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-          "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "split-on-first": {
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true
         },
         "sshpk": {
           "version": "1.14.2",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-          "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "asn1": "~0.2.3",
@@ -9943,8 +6634,7 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"
@@ -9952,8 +6642,7 @@
         },
         "stream-each": {
           "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
-          "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -9962,30 +6651,50 @@
         },
         "stream-iterate": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
-          "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "readable-stream": "^2.1.5",
             "stream-shift": "^1.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "stream-shift": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-          "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+          "bundled": true,
           "dev": true
         },
         "strict-uri-encode": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
+          "bundled": true,
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -9994,20 +6703,17 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "bundled": true,
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "bundled": true,
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -10016,24 +6722,21 @@
           }
         },
         "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "version": "1.2.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
         },
         "stringify-package": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.0.tgz",
-          "integrity": "sha512-JIQqiWmLiEozOC0b0BtxZ/AOUtdUZHCBPgqIZ2kSJJqGwgb9neo44XdTHUC4HZSGqi03hOeB7W/E8rAlKnGe9g==",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -10041,68 +6744,50 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+          "bundled": true,
           "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "bundled": true,
           "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
         },
         "tar": {
-          "version": "4.4.8",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+          "version": "4.4.12",
+          "bundled": true,
           "dev": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           },
           "dependencies": {
-            "chownr": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-              "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
-              "dev": true
-            },
             "minipass": {
-              "version": "2.3.5",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-              "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+              "version": "2.8.6",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
               }
-            },
-            "yallist": {
-              "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-              "dev": true
             }
           }
         },
         "term-size": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-          "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "execa": "^0.7.0"
@@ -10110,42 +6795,60 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+          "bundled": true,
           "dev": true
         },
         "through": {
           "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+          "bundled": true,
           "dev": true
         },
         "through2": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "readable-stream": "^2.1.5",
             "xtend": "~4.0.1"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
           }
         },
         "timed-out": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+          "bundled": true,
           "dev": true
         },
         "tiny-relative-date": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz",
-          "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==",
+          "bundled": true,
           "dev": true
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "psl": "^1.1.24",
@@ -10154,8 +6857,7 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
@@ -10163,33 +6865,28 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "typedarray": {
           "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+          "bundled": true,
           "dev": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+          "bundled": true,
           "dev": true
         },
         "umask": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-          "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
+          "bundled": true,
           "dev": true
         },
         "unique-filename": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
-          "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+          "version": "1.1.1",
+          "bundled": true,
           "dev": true,
           "requires": {
             "unique-slug": "^2.0.0"
@@ -10197,8 +6894,7 @@
         },
         "unique-slug": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
-          "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4"
@@ -10206,8 +6902,7 @@
         },
         "unique-string": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-          "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "crypto-random-string": "^1.0.0"
@@ -10215,20 +6910,17 @@
         },
         "unpipe": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+          "bundled": true,
           "dev": true
         },
         "unzip-response": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+          "bundled": true,
           "dev": true
         },
         "update-notifier": {
           "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
-          "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "boxen": "^1.2.1",
@@ -10245,8 +6937,7 @@
         },
         "url-parse-lax": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "prepend-http": "^1.0.1"
@@ -10254,26 +6945,30 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "bundled": true,
           "dev": true
         },
         "util-extend": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
-          "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
+          "bundled": true,
           "dev": true
+        },
+        "util-promisify": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object.getownpropertydescriptors": "^2.0.3"
+          }
         },
         "uuid": {
           "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+          "bundled": true,
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-          "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-correct": "^3.0.0",
@@ -10282,8 +6977,7 @@
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "builtins": "^1.0.3"
@@ -10291,8 +6985,7 @@
         },
         "verror": {
           "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
@@ -10302,8 +6995,7 @@
         },
         "wcwidth": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-          "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "defaults": "^1.0.3"
@@ -10311,8 +7003,7 @@
         },
         "which": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -10320,14 +7011,12 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "bundled": true,
           "dev": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "string-width": "^1.0.2"
@@ -10335,8 +7024,7 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -10348,17 +7036,15 @@
         },
         "widest-line": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
-          "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "string-width": "^2.1.1"
           }
         },
         "worker-farm": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
-          "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+          "version": "1.7.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "errno": "~0.1.7"
@@ -10366,8 +7052,7 @@
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "string-width": "^1.0.1",
@@ -10376,8 +7061,7 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -10389,14 +7073,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "dev": true
         },
         "write-file-atomic": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-          "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+          "version": "2.4.3",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -10406,32 +7088,27 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+          "bundled": true,
           "dev": true
         },
         "xtend": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "bundled": true,
           "dev": true
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "bundled": true,
           "dev": true
         },
         "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "version": "3.0.3",
+          "bundled": true,
           "dev": true
         },
         "yargs": {
           "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
-          "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cliui": "^4.0.0",
@@ -10450,16 +7127,14 @@
           "dependencies": {
             "y18n": {
               "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "yargs-parser": {
           "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "camelcase": "^4.1.0"
@@ -10625,9 +7300,9 @@
       "dev": true
     },
     "p-is-promise": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
-      "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
+      "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
       "dev": true
     },
     "p-limit": {
@@ -10692,12 +7367,6 @@
           "dev": true
         }
       }
-    },
-    "parse-github-url": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
-      "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
-      "dev": true
     },
     "parse-json": {
       "version": "4.0.0",
@@ -11064,9 +7733,9 @@
       "integrity": "sha1-QnelR1RIiqlnXYhuNU24lMm9yYE="
     },
     "semantic-release": {
-      "version": "15.13.24",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-15.13.24.tgz",
-      "integrity": "sha512-OPshm6HSp+KmZP9dUv1o3MRILDgOeHYWPI+XSpQRERMri7QkaEiIPkZzoNm2d6KDeFDnp03GphQQS4+Zfo+x/Q==",
+      "version": "15.13.28",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-15.13.28.tgz",
+      "integrity": "sha512-TqmRAsTFPq+hi0LjccUIHIknpW2wBPqVZWc/fVBBeeokuZ+wfGcP/Vo8nKci7VTHBl0D/EAu6gNvo343dKjWUA==",
       "dev": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^6.1.0",
@@ -11078,7 +7747,7 @@
         "cosmiconfig": "^5.0.1",
         "debug": "^4.0.0",
         "env-ci": "^4.0.0",
-        "execa": "^1.0.0",
+        "execa": "^3.2.0",
         "figures": "^3.0.0",
         "find-versions": "^3.0.0",
         "get-stream": "^5.0.0",
@@ -11090,53 +7759,46 @@
         "marked-terminal": "^3.2.0",
         "p-locate": "^4.0.0",
         "p-reduce": "^2.0.0",
-        "read-pkg-up": "^6.0.0",
+        "read-pkg-up": "^7.0.0",
         "resolve-from": "^5.0.0",
         "semver": "^6.0.0",
         "signale": "^1.2.1",
         "yargs": "^14.0.0"
       },
       "dependencies": {
-        "aggregate-error": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.0.tgz",
-          "integrity": "sha512-yKD9kEoJIR+2IFqhMwayIBgheLYbB3PS2OBhWae1L/ODTd/JF/30cW0bc9TqzRL3k4U41Dieu3BF4I29p8xesA==",
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
           "dev": true,
           "requires": {
-            "clean-stack": "^2.0.0",
-            "indent-string": "^3.2.0"
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
           }
         },
         "execa": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-3.2.0.tgz",
+          "integrity": "sha512-kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==",
           "dev": true,
           "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          },
-          "dependencies": {
-            "get-stream": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-              "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-              "dev": true,
-              "requires": {
-                "pump": "^3.0.0"
-              }
-            }
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
           }
         },
         "figures": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
-          "integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
+          "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
           "dev": true,
           "requires": {
             "escape-string-regexp": "^1.0.5"
@@ -11162,13 +7824,19 @@
           }
         },
         "hosted-git-info": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.0.tgz",
-          "integrity": "sha512-zYSx1cP4MLsvKtTg8DF/PI6e6FHZ3wcawcTGsrLU2TM+UfD4jmSrn2wdQT16TFbH3lO4PIdjLG0E+cuYDgFD9g==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.2.tgz",
+          "integrity": "sha512-ezZMWtHXm7Eb7Rq4Mwnx2vs79WUx2QmRg3+ZqeGroKzfDO+EprOcgRPYghsOP9JuYBfK18VojmRTGCg8Ma+ktw==",
           "dev": true,
           "requires": {
             "lru-cache": "^5.1.1"
           }
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
         },
         "locate-path": {
           "version": "5.0.0",
@@ -11179,10 +7847,10 @@
             "p-locate": "^4.1.0"
           }
         },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "dev": true
         },
         "normalize-package-data": {
@@ -11198,9 +7866,9 @@
           },
           "dependencies": {
             "hosted-git-info": {
-              "version": "2.8.4",
-              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-              "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+              "version": "2.8.5",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+              "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
               "dev": true
             },
             "semver": {
@@ -11210,6 +7878,30 @@
               "dev": true
             }
           }
+        },
+        "npm-run-path": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.0.tgz",
+          "integrity": "sha512-8eyAOAH+bYXFPSnNnKr3J+yoybe8O87Is5rtAQ8qRczJz1ajcsjg8l2oZqP+Ppx15Ii3S1vUTjQN2h4YO2tWWQ==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+          "dev": true
         },
         "p-limit": {
           "version": "2.2.1",
@@ -11228,12 +7920,6 @@
           "requires": {
             "p-limit": "^2.2.0"
           }
-        },
-        "p-reduce": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
-          "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
-          "dev": true
         },
         "p-try": {
           "version": "2.2.0",
@@ -11259,6 +7945,12 @@
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
         },
+        "path-key": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+          "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+          "dev": true
+        },
         "read-pkg": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -11280,14 +7972,14 @@
           }
         },
         "read-pkg-up": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-6.0.0.tgz",
-          "integrity": "sha512-odtTvLl+EXo1eTsMnoUHRmg/XmXdTkwXVxy4VFE9Kp6cCq7b3l7QMdBndND3eAFzrbSAXC/WCUOQQ9rLjifKZw==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.0.tgz",
+          "integrity": "sha512-t2ODkS/vTTcRlKwZiZsaLGb5iwfx9Urp924aGzVyboU6+7Z2i6eGr/G1Z4mjvwLLQV3uFOBKobNRGM3ux2PD/w==",
           "dev": true,
           "requires": {
-            "find-up": "^4.0.0",
-            "read-pkg": "^5.1.1",
-            "type-fest": "^0.5.0"
+            "find-up": "^4.1.0",
+            "read-pkg": "^5.2.0",
+            "type-fest": "^0.8.1"
           }
         },
         "resolve-from": {
@@ -11302,11 +7994,35 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         },
-        "type-fest": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
-          "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
           "dev": true
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
+          "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
     },
@@ -11615,6 +8331,31 @@
         }
       }
     },
+    "temp-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
+      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
+      "dev": true
+    },
+    "tempy": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.3.0.tgz",
+      "integrity": "sha512-WrH/pui8YCwmeiAoxV+lpRH9HpRtgBhSR2ViBPgpGb/wnYDzp21R4MN45fsCGvLROvY67o3byhJRYRONJyImVQ==",
+      "dev": true,
+      "requires": {
+        "temp-dir": "^1.0.0",
+        "type-fest": "^0.3.1",
+        "unique-string": "^1.0.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+          "dev": true
+        }
+      }
+    },
     "text-extensions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -11700,14 +8441,23 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.4.tgz",
+      "integrity": "sha512-9Yc2i881pF4BPGhjteCXQNaXx1DCwm3dtOyBaG2hitHjLWOczw/ki8vD1bqyT3u6K0Ms/FpCShkmfg+FtlOfYA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
+      }
+    },
+    "unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "^1.0.0"
       }
     },
     "universal-user-agent": {
@@ -11861,15 +8611,15 @@
       "dev": true
     },
     "yallist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
     "yargs": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.0.0.tgz",
-      "integrity": "sha512-ssa5JuRjMeZEUjg7bEL99AwpitxU/zWGAGpdj0di41pOEmJti8NR6kyUIJBkR78DTYNPZOU08luUo0GTHuB+ow==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.0.tgz",
+      "integrity": "sha512-/is78VKbKs70bVZH7w4YaZea6xcJWOAwkhbR0CFuZBmYtfTYF0xjGJF43AYd8g2Uii1yJwmS5GR2vBmrc32sbg==",
       "dev": true,
       "requires": {
         "cliui": "^5.0.0",
@@ -11882,7 +8632,7 @@
         "string-width": "^3.0.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.1"
+        "yargs-parser": "^15.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -11946,9 +8696,9 @@
           }
         },
         "yargs-parser": {
-          "version": "13.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+          "version": "15.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
+          "integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
     "@commitlint/cli": "8.2.0",
     "@commitlint/config-conventional": "8.2.0",
     "@commitlint/travis-cli": "8.2.0",
-    "@semantic-release/apm-config": "6.0.1",
+    "@semantic-release/apm-config": "6.0.2",
     "eslint": "6.4.0",
     "eslint-config-airbnb-base": "14.0.0",
     "eslint-plugin-import": "2.18.2",
     "husky": "3.0.5",
     "jasmine-fix": "1.3.1",
-    "semantic-release": "15.13.24"
+    "semantic-release": "15.13.28"
   },
   "engines": {
     "atom": ">=1.7.0 <2.0.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@commitlint/config-conventional": "8.2.0",
     "@commitlint/travis-cli": "8.2.0",
     "@semantic-release/apm-config": "6.0.2",
-    "eslint": "6.4.0",
+    "eslint": "6.6.0",
     "eslint-config-airbnb-base": "14.0.0",
     "eslint-plugin-import": "2.18.2",
     "husky": "3.0.9",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint": "6.4.0",
     "eslint-config-airbnb-base": "14.0.0",
     "eslint-plugin-import": "2.18.2",
-    "husky": "3.0.5",
+    "husky": "3.0.9",
     "jasmine-fix": "1.3.1",
     "semantic-release": "15.13.28"
   },


### PR DESCRIPTION
Update all out of date dependencies.

`npm audit` is complaining of several instances of a single issue, however it's not one that we can fix here and only affects a `devDependency` so it's not one that users will hit anyway.